### PR TITLE
Update backend API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains a simple frontend built with **Vue 3** and **Vite**. It
    npm run dev
    ```
 
-The application expects a backend available at `http://localhost:8000/api`. If your API runs elsewhere, update the `baseURL` setting in [`src/services/cameraService.js`](src/services/cameraService.js).
+The application expects a backend available at `http://127.0.0.1:18006`. If your API runs elsewhere, update the `baseURL` setting in [`src/services/cameraService.js`](src/services/cameraService.js).
 
 ## Building for Production
 

--- a/src/services/cameraService.js
+++ b/src/services/cameraService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://localhost:8000/api',  // ← adjust to your backend
+  baseURL: 'http://127.0.0.1:18006',  // ← adjust to your backend
   timeout: 5000,
 })
 

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://localhost:8000/api',
+  baseURL: 'http://127.0.0.1:18006',
   timeout: 5000,
 })
 

--- a/src/services/poleService.js
+++ b/src/services/poleService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://localhost:8000/api',
+  baseURL: 'http://127.0.0.1:18006',
   timeout: 5000,
 })
 

--- a/src/services/zoneService.js
+++ b/src/services/zoneService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://localhost:8000/api',
+  baseURL: 'http://127.0.0.1:18006',
   timeout: 5000,
 })
 


### PR DESCRIPTION
## Summary
- point to new backend URL `http://127.0.0.1:18006`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846b1b4053083268fd0a4edd5ca4434