### PR TITLE
Show camera/spot info in ticket list

### DIFF
--- a/src/components/tickets/TicketsList.vue
+++ b/src/components/tickets/TicketsList.vue
@@ -13,6 +13,8 @@
           <th>ID</th>
           <th>Plate Number</th>
           <th>Plate Code</th>
+          <th>Camera ID</th>
+          <th>Spot Number</th>
           <th>Entry Time</th>
           <th>Exit Time</th>
           <th>Actions</th>
@@ -23,6 +25,8 @@
           <td>{{ ticket.id }}</td>
           <td>{{ ticket.plate_number }}</td>
           <td>{{ ticket.plate_code }}</td>
+          <td>{{ ticket.camera_id }}</td>
+          <td>{{ ticket.spot_number }}</td>
           <td>{{ ticket.entry_time }}</td>
           <td>{{ ticket.exit_time }}</td>
           <td>


### PR DESCRIPTION
## Summary
- show `camera_id` and `spot_number` columns in tickets table

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c91c817483268a65f4528c38d0c1