### PR TITLE
Add manual review CRUD interface

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@
         <router-link class="nav-link" to="/zones">Zones</router-link>
         <router-link class="nav-link" to="/poles">Poles</router-link>
         <router-link class="nav-link" to="/tickets">Tickets</router-link>
+        <router-link class="nav-link" to="/manual-reviews">Manual Reviews</router-link>
       </div>
     </div>
   </nav>

--- a/src/components/manualReviews/ManualReviewDetail.vue
+++ b/src/components/manualReviews/ManualReviewDetail.vue
@@ -1,0 +1,94 @@
+<template>
+  <div v-if="review">
+    <h1>Manual Review #{{ review.id }}</h1>
+    <ul class="list-group mb-3">
+      <li class="list-group-item">Status: {{ review.status }}</li>
+      <li class="list-group-item">Detected Plate: {{ review.plate_number }}</li>
+    </ul>
+
+    <div v-if="plateImage" class="mb-3">
+      <h3>Plate Image</h3>
+      <img :src="plateImage" class="img-fluid" />
+    </div>
+
+    <div v-if="snapshots.length" class="mb-3">
+      <h3>Snapshots</h3>
+      <div>
+        <img v-for="snap in snapshots" :key="snap" :src="snap" class="img-thumbnail me-2 mb-2" />
+      </div>
+    </div>
+
+    <div v-if="video" class="mb-3">
+      <h3>Video</h3>
+      <video :src="video" controls class="w-100" />
+    </div>
+
+    <div class="mb-3">
+      <h3>Correct Plate</h3>
+      <input v-model="correction.plate_number" class="form-control mb-2" placeholder="Plate number" />
+      <input v-model="correction.plate_code" class="form-control mb-2" placeholder="Plate code" />
+      <input v-model="correction.plate_city" class="form-control mb-2" placeholder="Plate city" />
+      <button class="btn btn-primary me-2" @click="submitCorrection">Submit</button>
+      <button class="btn btn-danger" @click="dismiss">Dismiss</button>
+    </div>
+
+    <router-link to="/manual-reviews" class="btn btn-secondary">Back</router-link>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import manualReviewService from '@/services/manualReviewService'
+
+const route = useRoute()
+const router = useRouter()
+
+const review = ref(null)
+const plateImage = ref('')
+const video = ref('')
+const snapshots = ref([])
+
+const correction = ref({
+  plate_number: '',
+  plate_code: '',
+  plate_city: '',
+})
+
+onMounted(async () => {
+  const { data } = await manualReviewService.get(route.params.id)
+  review.value = data
+
+  try {
+    const imgRes = await manualReviewService.getImage(route.params.id)
+    plateImage.value = URL.createObjectURL(imgRes.data)
+  } catch (_) {}
+
+  try {
+    const vidRes = await manualReviewService.getVideo(route.params.id)
+    video.value = URL.createObjectURL(vidRes.data)
+  } catch (_) {}
+
+  try {
+    const { data: snaps } = await manualReviewService.listSnapshots(route.params.id)
+    snapshots.value = await Promise.all(
+      (snaps || []).map(async name => {
+        const { data } = await manualReviewService.getSnapshot(route.params.id, name)
+        return URL.createObjectURL(data)
+      })
+    )
+  } catch (_) {}
+})
+
+async function submitCorrection() {
+  await manualReviewService.correct(route.params.id, correction.value)
+  router.push('/manual-reviews')
+}
+
+async function dismiss() {
+  if (confirm('Dismiss this review?')) {
+    await manualReviewService.dismiss(route.params.id)
+    router.push('/manual-reviews')
+  }
+}
+</script>

--- a/src/components/manualReviews/ManualReviewsList.vue
+++ b/src/components/manualReviews/ManualReviewsList.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <h1>Manual Reviews</h1>
+    <div class="row mb-3">
+      <div class="col-md-3">
+        <select v-model="status" @change="fetchReviews" class="form-select">
+          <option value="">All</option>
+          <option value="PENDING">Pending</option>
+          <option value="CORRECTED">Corrected</option>
+          <option value="DISMISSED">Dismissed</option>
+        </select>
+      </div>
+    </div>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Plate</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="rev in reviews" :key="rev.id">
+          <td>{{ rev.id }}</td>
+          <td>{{ rev.plate_number || rev.plate }}</td>
+          <td>{{ rev.status }}</td>
+          <td>
+            <router-link :to="`/manual-reviews/${rev.id}`" class="btn btn-sm btn-secondary">View</router-link>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <nav>
+      <ul class="pagination">
+        <li class="page-item" :class="{ disabled: page === 1 }">
+          <button class="page-link" @click="prevPage">Previous</button>
+        </li>
+        <li class="page-item" :class="{ disabled: page * pageSize >= total }">
+          <button class="page-link" @click="nextPage">Next</button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import manualReviewService from '@/services/manualReviewService'
+
+const reviews = ref([])
+const page = ref(1)
+const pageSize = ref(50)
+const total = ref(0)
+const status = ref('PENDING')
+
+async function fetchReviews() {
+  const { data } = await manualReviewService.getAll({
+    status: status.value || undefined,
+    page: page.value,
+    page_size: pageSize.value,
+  })
+  reviews.value = data.data ?? data.items ?? data
+  total.value = data.total ?? reviews.value.length
+}
+
+function nextPage() {
+  if (page.value * pageSize.value < total.value) page.value++
+}
+
+function prevPage() {
+  if (page.value > 1) page.value--
+}
+
+watch([page, pageSize], fetchReviews)
+watch(status, () => { page.value = 1; fetchReviews() })
+
+onMounted(fetchReviews)
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,6 +19,9 @@ import TicketsList from '@/components/tickets/TicketsList.vue'
 import TicketForm   from '@/components/tickets/TicketForm.vue'
 import TicketDetail from '@/components/tickets/TicketDetail.vue'
 
+import ManualReviewsList from '@/components/manualReviews/ManualReviewsList.vue'
+import ManualReviewDetail from '@/components/manualReviews/ManualReviewDetail.vue'
+
 const routes = [
   { path: '/', redirect: '/cameras' },
   { path: '/cameras',          component: CamerasList },
@@ -44,6 +47,9 @@ const routes = [
   { path: '/tickets/create',   component: TicketForm,   props: { isEdit: false } },
   { path: '/tickets/:id/edit', component: TicketForm,   props: route => ({ isEdit: true, id: +route.params.id }) },
   { path: '/tickets/:id',      component: TicketDetail, props: true },
+
+  { path: '/manual-reviews', component: ManualReviewsList },
+  { path: '/manual-reviews/:id', component: ManualReviewDetail, props: true },
 ]
 
 export default createRouter({

--- a/src/services/manualReviewService.js
+++ b/src/services/manualReviewService.js
@@ -1,0 +1,19 @@
+import axios from 'axios'
+
+const API = axios.create({
+  baseURL: 'http://127.0.0.1:18006',
+  timeout: 5000,
+})
+
+export default {
+  getAll(params = {}) { return API.get('/manual-reviews', { params }) },
+  get(id) { return API.get(`/manual-reviews/${id}`) },
+  getImage(id) { return API.get(`/manual-reviews/${id}/image`, { responseType: 'blob' }) },
+  getVideo(id) { return API.get(`/manual-reviews/${id}/video`, { responseType: 'blob' }) },
+  listSnapshots(id) { return API.get(`/manual-reviews/${id}/snapshots`) },
+  getSnapshot(id, filename) {
+    return API.get(`/manual-reviews/${id}/snapshots/${filename}`, { responseType: 'blob' })
+  },
+  correct(id, payload) { return API.post(`/manual-reviews/${id}/correct`, payload) },
+  dismiss(id) { return API.post(`/manual-reviews/${id}/dismiss`) },
+}


### PR DESCRIPTION
## Summary
- add manual review service for API calls
- show list of manual reviews with status filter and pagination
- allow viewing manual review details, media, and correcting/dismissing
- register new routes and menu link

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846d122b90883269ff1c77af22ba368