### PR TITLE
Handle new manual-review field names

### DIFF
--- a/src/components/manualReviews/ManualReviewDetail.vue
+++ b/src/components/manualReviews/ManualReviewDetail.vue
@@ -2,8 +2,8 @@
   <div v-if="review">
     <h1>Manual Review #{{ review.id }}</h1>
     <ul class="list-group mb-3">
-      <li class="list-group-item">Status: {{ review.status }}</li>
-      <li class="list-group-item">Detected Plate: {{ review.plate_number }}</li>
+      <li class="list-group-item">Status: {{ review.status || review.review_status }}</li>
+      <li class="list-group-item">Detected Plate: {{ review.plate_number || review.plate || review.plate_status }}</li>
     </ul>
 
     <div v-if="plateImage" class="mb-3">

--- a/src/components/manualReviews/ManualReviewsList.vue
+++ b/src/components/manualReviews/ManualReviewsList.vue
@@ -23,8 +23,10 @@
       <tbody>
         <tr v-for="rev in reviews" :key="rev.id">
           <td>{{ rev.id }}</td>
-          <td>{{ rev.plate_number || rev.plate }}</td>
-          <td>{{ rev.status }}</td>
+          <!-- Plate may be returned under different property names. -->
+          <td>{{ rev.plate_number || rev.plate || rev.plate_status }}</td>
+          <!-- Support `review_status` for backward compatibility. -->
+          <td>{{ rev.status || rev.review_status }}</td>
           <td>
             <router-link :to="`/manual-reviews/${rev.id}`" class="btn btn-sm btn-secondary">View</router-link>
           </td>


### PR DESCRIPTION
## Summary
- show `review_status` and `plate_status` values if newer API fields are missing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846d2f15b208326a0b187a1131e0cd8