### PR TITLE
Use API URL from env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://127.0.0.1:18006

--- a/README.md
+++ b/README.md
@@ -8,12 +8,17 @@ This repository contains a simple frontend built with **Vue 3** and **Vite**. It
    ```bash
    npm install
    ```
-2. Start the development server:
+2. Copy the `.env` file and adjust it if your backend runs on a different host:
+   ```bash
+   cp .env .env.local
+   # edit .env.local to change VITE_API_BASE_URL if needed
+   ```
+3. Start the development server:
    ```bash
    npm run dev
    ```
 
-The application expects a backend available at `http://127.0.0.1:18006`. If your API runs elsewhere, update the `baseURL` setting in the service files under [`src/services`](src/services).
+The application reads `VITE_API_BASE_URL` from the environment to locate the backend API. The default value in `.env` points to `http://127.0.0.1:18006`.
 
 ## Building for Production
 

--- a/src/services/cameraService.js
+++ b/src/services/cameraService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:18006',  // ← adjust to your backend
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
 })
 

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:18006',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
 })
 

--- a/src/services/manualReviewService.js
+++ b/src/services/manualReviewService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:18006',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
 })
 

--- a/src/services/poleService.js
+++ b/src/services/poleService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:18006',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
 })
 

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:18006',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
 })
 

--- a/src/services/zoneService.js
+++ b/src/services/zoneService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:18006',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
 })
 


### PR DESCRIPTION
## Summary
- set VITE_API_BASE_URL in `.env`
- read API base URL from env in service modules
- update README with instructions for customizing the environment variable

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846d3ce987883269f98c1ebe2f82a78