### PR TITLE
Add manual transactions list

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@
         <router-link class="nav-link" to="/poles">Poles</router-link>
         <router-link class="nav-link" to="/tickets">Tickets</router-link>
         <router-link class="nav-link" to="/manual-reviews">Manual Reviews</router-link>
+        <router-link class="nav-link" to="/manual-transactions">Manual Transactions</router-link>
       </div>
     </div>
   </nav>

--- a/src/components/manualTransactions/ManualTransactionsList.vue
+++ b/src/components/manualTransactions/ManualTransactionsList.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <h1>Manual Transactions</h1>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Camera</th>
+          <th>Spot #</th>
+          <th>Event Time</th>
+          <th>Plate Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="tx in transactions" :key="tx.id">
+          <td>{{ tx.id }}</td>
+          <td>{{ tx.camera_id }}</td>
+          <td>{{ tx.spot_number }}</td>
+          <td>{{ tx.event_time }}</td>
+          <td>{{ tx.plate_status }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import manualTransactionService from '@/services/manualTransactionService'
+
+const transactions = ref([])
+
+async function fetchTransactions() {
+  const { data } = await manualTransactionService.getAll()
+  transactions.value = data.data ?? data.items ?? data
+}
+
+onMounted(fetchTransactions)
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -21,6 +21,7 @@ import TicketDetail from '@/components/tickets/TicketDetail.vue'
 
 import ManualReviewsList from '@/components/manualReviews/ManualReviewsList.vue'
 import ManualReviewDetail from '@/components/manualReviews/ManualReviewDetail.vue'
+import ManualTransactionsList from '@/components/manualTransactions/ManualTransactionsList.vue'
 
 const routes = [
   { path: '/', redirect: '/cameras' },
@@ -50,6 +51,7 @@ const routes = [
 
   { path: '/manual-reviews', component: ManualReviewsList },
   { path: '/manual-reviews/:id', component: ManualReviewDetail, props: true },
+  { path: '/manual-transactions', component: ManualTransactionsList },
 ]
 
 export default createRouter({

--- a/src/services/manualTransactionService.js
+++ b/src/services/manualTransactionService.js
@@ -1,0 +1,11 @@
+import axios from 'axios'
+
+const API = axios.create({
+  baseURL: 'http://127.0.0.1:18006',
+  timeout: 5000,
+})
+
+export default {
+  getAll(params = {}) { return API.get('/manual-transactions', { params }) },
+  get(id) { return API.get(`/manual-transactions/${id}`) },
+}


### PR DESCRIPTION
## Summary
- add service for manual transactions
- list manual transactions with a new component
- register the page in Vue router and navbar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846d3d34ff48326921769f7d2d1cefb