### PR TITLE
Add api_pole_id support for poles

### DIFF
--- a/src/components/poles/PoleDetail.vue
+++ b/src/components/poles/PoleDetail.vue
@@ -2,6 +2,7 @@
   <div v-if="pole">
     <h1>Pole #{{ pole.id }}</h1>
     <ul class="list-group mb-3">
+      <li class="list-group-item">API Pole ID: {{ pole.api_pole_id }}</li>
       <li class="list-group-item">Code: {{ pole.code }}</li>
       <li class="list-group-item">Zone ID: {{ pole.zone_id }}</li>
       <li class="list-group-item">Location ID: {{ pole.location_id }}</li>

--- a/src/components/poles/PoleForm.vue
+++ b/src/components/poles/PoleForm.vue
@@ -7,6 +7,10 @@
         <input v-model="form.zone_id" type="number" class="form-control" />
       </div>
       <div class="mb-3">
+        <label class="form-label">API Pole ID</label>
+        <input v-model="form.api_pole_id" class="form-control" />
+      </div>
+      <div class="mb-3">
         <label class="form-label">Code</label>
         <input v-model="form.code" class="form-control" />
       </div>
@@ -35,6 +39,7 @@ const props = defineProps({ isEdit: Boolean, id: Number })
 
 const form = reactive({
   zone_id: 1,
+  api_pole_id: '',
   code: '',
   location_id: 1,
   number_of_cameras: 0

--- a/src/components/poles/PolesList.vue
+++ b/src/components/poles/PolesList.vue
@@ -5,12 +5,13 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th><th>Code</th><th>Zone</th><th>Location</th><th>Actions</th>
+          <th>ID</th><th>API Pole ID</th><th>Code</th><th>Zone</th><th>Location</th><th>Actions</th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="pole in poles" :key="pole.id">
           <td>{{ pole.id }}</td>
+          <td>{{ pole.api_pole_id }}</td>
           <td>{{ pole.code }}</td>
           <td>{{ pole.zone_id }}</td>
           <td>{{ pole.location_id }}</td>


### PR DESCRIPTION
## Summary
- display `api_pole_id` when listing, viewing and editing poles

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d295f190832692a3f85f80fa0433