### PR TITLE
Add auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ This repository contains a simple frontend built with **Vue 3** and **Vite**. It
 
 The application reads `VITE_API_BASE_URL` from the environment to locate the backend API. The default value in `.env` points to `http://127.0.0.1:18006`.
 
+## Authentication
+
+All API endpoints are now protected by JWT authentication. Obtain a token by
+sending your username and password to the `/token` endpoint:
+
+```bash
+curl -X POST http://127.0.0.1:18006/token \
+     -d 'username=<user>' -d 'password=<pass>'
+```
+
+The returned `access_token` can be used to sign in through the `/login` page of
+the UI. After logging in, the token will be stored in the browser and
+automatically sent with every request.
+
 ## Building for Production
 
 Generate optimized assets in the `dist` directory with:

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,8 @@
         <router-link class="nav-link" to="/poles">Poles</router-link>
         <router-link class="nav-link" to="/tickets">Tickets</router-link>
         <router-link class="nav-link" to="/manual-reviews">Manual Reviews</router-link>
+        <router-link v-if="!auth.token" class="nav-link" to="/login">Login</router-link>
+        <a v-else class="nav-link" href="#" @click.prevent="logout">Logout</a>
       </div>
     </div>
   </nav>
@@ -17,3 +19,16 @@
     <router-view />
   </div>
 </template>
+
+<script setup>
+import { useAuthStore } from '@/stores/auth'
+import { useRouter } from 'vue-router'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+function logout() {
+  auth.clearToken()
+  router.push('/login')
+}
+</script>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <h1>Login</h1>
+    <form @submit.prevent="submit">
+      <div class="mb-3">
+        <label class="form-label">Username</label>
+        <input v-model="username" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" v-model="password" class="form-control" />
+      </div>
+      <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { login as loginRequest } from '@/services/authService'
+
+const router = useRouter()
+const auth = useAuthStore()
+
+const username = ref('')
+const password = ref('')
+
+async function submit() {
+  try {
+    const { data } = await loginRequest(username.value, password.value)
+    auth.setToken(data.access_token)
+    router.push('/')
+  } catch (err) {
+    alert('Invalid credentials')
+  }
+}
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,9 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap'
 import './style.css'
 
+const pinia = createPinia()
+
 createApp(App)
+  .use(pinia)
   .use(router)
-  .use(createPinia())
   .mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -21,8 +21,11 @@ import TicketDetail from '@/components/tickets/TicketDetail.vue'
 
 import ManualReviewsList from '@/components/manualReviews/ManualReviewsList.vue'
 import ManualReviewDetail from '@/components/manualReviews/ManualReviewDetail.vue'
+import Login from '@/components/Login.vue'
+import { useAuthStore } from '@/stores/auth'
 
 const routes = [
+  { path: '/login', component: Login },
   { path: '/', redirect: '/cameras' },
   { path: '/cameras',          component: CamerasList },
   { path: '/cameras/create',   component: CameraForm,   props: { isEdit: false } },
@@ -52,7 +55,20 @@ const routes = [
   { path: '/manual-reviews/:id', component: ManualReviewDetail, props: true },
 ]
 
-export default createRouter({
+const router = createRouter({
   history: createWebHistory(),
   routes
 })
+
+router.beforeEach((to, from, next) => {
+  const publicPages = ['/login']
+  const authRequired = !publicPages.includes(to.path)
+  const auth = useAuthStore()
+
+  if (authRequired && !auth.token) {
+    return next('/login')
+  }
+  next()
+})
+
+export default router

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,17 @@
+import axios from 'axios'
+import { useAuthStore } from '@/stores/auth'
+
+const API = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  timeout: 5000,
+})
+
+API.interceptors.request.use(config => {
+  const auth = useAuthStore()
+  if (auth.token) {
+    config.headers.Authorization = `Bearer ${auth.token}`
+  }
+  return config
+})
+
+export default API

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,8 @@
+import API from './api'
+
+export function login(username, password) {
+  const params = new URLSearchParams()
+  params.append('username', username)
+  params.append('password', password)
+  return API.post('/token', params)
+}

--- a/src/services/cameraService.js
+++ b/src/services/cameraService.js
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const API = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 5000,
-})
+import API from './api'
 
 export default {
   getAll()           { return API.get('/cameras') },

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const API = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 5000,
-})
+import API from './api'
 
 export default {
   getAll()            { return API.get('/locations') },

--- a/src/services/manualReviewService.js
+++ b/src/services/manualReviewService.js
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const API = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 5000,
-})
+import API from './api'
 
 export default {
   getAll(params = {}) { return API.get('/manual-reviews', { params }) },

--- a/src/services/poleService.js
+++ b/src/services/poleService.js
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const API = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 5000,
-})
+import API from './api'
 
 export default {
   getAll()            { return API.get('/poles') },

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const API = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 5000,
-})
+import API from './api'
 
 export default {
   getAll(params = {}) { return API.get('/tickets', { params }) },

--- a/src/services/zoneService.js
+++ b/src/services/zoneService.js
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const API = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 5000,
-})
+import API from './api'
 
 export default {
   getAll()            { return API.get('/zones') },

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,0 +1,17 @@
+import { defineStore } from 'pinia'
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    token: localStorage.getItem('token') || ''
+  }),
+  actions: {
+    setToken(token) {
+      this.token = token
+      localStorage.setItem('token', token)
+    },
+    clearToken() {
+      this.token = ''
+      localStorage.removeItem('token')
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- implement authentication store
- use API instance with bearer token
- add login form and auth-aware navigation
- require login via navigation guard
- document backend token usage

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68482d61ee0483268d89ebe97ded8939