### PR TITLE
Add user/role/permission management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Parking Management UI
 
 This repository contains a simple frontend built with **Vue 3** and **Vite**. It provides a basic interface for managing parking cameras, tickets, and other resources, demonstrating CRUD operations against a REST API.
+Recent updates introduce management screens for **Users**, **Roles** and **Permissions**. Access to these pages is restricted to accounts with the `admin` role which is extracted from the JWT token.
 
 ## Getting Started
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,9 @@
         <router-link class="nav-link" to="/poles">Poles</router-link>
         <router-link class="nav-link" to="/tickets">Tickets</router-link>
         <router-link class="nav-link" to="/manual-reviews">Manual Reviews</router-link>
+        <router-link v-if="auth.roles.includes('admin')" class="nav-link" to="/users">Users</router-link>
+        <router-link v-if="auth.roles.includes('admin')" class="nav-link" to="/roles">Roles</router-link>
+        <router-link v-if="auth.roles.includes('admin')" class="nav-link" to="/permissions">Permissions</router-link>
         <router-link v-if="!auth.token" class="nav-link" to="/login">Login</router-link>
         <a v-else class="nav-link" href="#" @click.prevent="logout">Logout</a>
       </div>

--- a/src/components/permissions/PermissionDetail.vue
+++ b/src/components/permissions/PermissionDetail.vue
@@ -1,0 +1,23 @@
+<template>
+  <div v-if="permission">
+    <h1>Permission #{{ permission.id }}</h1>
+    <ul class="list-group mb-3">
+      <li class="list-group-item">Name: {{ permission.name }}</li>
+    </ul>
+    <router-link to="/permissions" class="btn btn-secondary">Back to list</router-link>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import permissionService from '@/services/permissionService'
+
+const route = useRoute()
+const permission = ref(null)
+
+onMounted(async () => {
+  const { data } = await permissionService.get(route.params.id)
+  permission.value = data
+})
+</script>

--- a/src/components/permissions/PermissionForm.vue
+++ b/src/components/permissions/PermissionForm.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <h1>{{ isEdit ? 'Edit' : 'Create' }} Permission</h1>
+    <form @submit.prevent="submit">
+      <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input v-model="form.name" class="form-control" />
+      </div>
+      <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import permissionService from '@/services/permissionService'
+
+const router = useRouter()
+const props = defineProps({ isEdit: Boolean, id: Number })
+
+const form = reactive({ name: '' })
+
+onMounted(async () => {
+  if (props.isEdit) {
+    const { data } = await permissionService.get(props.id)
+    form.name = data.name
+  }
+})
+
+async function submit() {
+  if (props.isEdit) {
+    await permissionService.update(props.id, form)
+  } else {
+    await permissionService.create(form)
+  }
+  router.push('/permissions')
+}
+</script>

--- a/src/components/permissions/PermissionsList.vue
+++ b/src/components/permissions/PermissionsList.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <h1>Permissions</h1>
+    <router-link to="/permissions/create" class="btn btn-primary mb-3">Add New Permission</router-link>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>ID</th><th>Name</th><th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="p in permissions" :key="p.id">
+          <td>{{ p.id }}</td>
+          <td>{{ p.name }}</td>
+          <td>
+            <router-link :to="`/permissions/${p.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
+            <router-link :to="`/permissions/${p.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
+            <button class="btn btn-sm btn-danger" @click.prevent="remove(p.id)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import permissionService from '@/services/permissionService'
+
+const permissions = ref([])
+
+async function load() {
+  const { data } = await permissionService.getAll()
+  permissions.value = data
+}
+
+async function remove(id) {
+  if (confirm('Are you sure?')) {
+    await permissionService.remove(id)
+    load()
+  }
+}
+
+onMounted(load)
+</script>

--- a/src/components/roles/RoleDetail.vue
+++ b/src/components/roles/RoleDetail.vue
@@ -1,0 +1,24 @@
+<template>
+  <div v-if="role">
+    <h1>Role #{{ role.id }}</h1>
+    <ul class="list-group mb-3">
+      <li class="list-group-item">Name: {{ role.name }}</li>
+      <li class="list-group-item">Permissions: {{ (role.permissions || []).map(p => p.name).join(', ') }}</li>
+    </ul>
+    <router-link to="/roles" class="btn btn-secondary">Back to list</router-link>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import roleService from '@/services/roleService'
+
+const route = useRoute()
+const role = ref(null)
+
+onMounted(async () => {
+  const { data } = await roleService.get(route.params.id)
+  role.value = data
+})
+</script>

--- a/src/components/roles/RoleForm.vue
+++ b/src/components/roles/RoleForm.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <h1>{{ isEdit ? 'Edit' : 'Create' }} Role</h1>
+    <form @submit.prevent="submit">
+      <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input v-model="form.name" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Permissions</label>
+        <select v-model="form.permission_ids" multiple class="form-select">
+          <option v-for="p in permissions" :key="p.id" :value="p.id">{{ p.name }}</option>
+        </select>
+      </div>
+      <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { reactive, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import roleService from '@/services/roleService'
+import permissionService from '@/services/permissionService'
+
+const router = useRouter()
+const props = defineProps({ isEdit: Boolean, id: Number })
+
+const permissions = ref([])
+const form = reactive({
+  name: '',
+  permission_ids: []
+})
+
+onMounted(async () => {
+  const { data: permData } = await permissionService.getAll()
+  permissions.value = permData
+  if (props.isEdit) {
+    const { data } = await roleService.get(props.id)
+    form.name = data.name
+    form.permission_ids = (data.permissions || []).map(p => p.id)
+  }
+})
+
+async function submit() {
+  if (props.isEdit) {
+    await roleService.update(props.id, form)
+  } else {
+    await roleService.create(form)
+  }
+  router.push('/roles')
+}
+</script>

--- a/src/components/roles/RolesList.vue
+++ b/src/components/roles/RolesList.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <h1>Roles</h1>
+    <router-link to="/roles/create" class="btn btn-primary mb-3">Add New Role</router-link>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>ID</th><th>Name</th><th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="r in roles" :key="r.id">
+          <td>{{ r.id }}</td>
+          <td>{{ r.name }}</td>
+          <td>
+            <router-link :to="`/roles/${r.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
+            <router-link :to="`/roles/${r.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
+            <button class="btn btn-sm btn-danger" @click.prevent="remove(r.id)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import roleService from '@/services/roleService'
+
+const roles = ref([])
+
+async function load() {
+  const { data } = await roleService.getAll()
+  roles.value = data
+}
+
+async function remove(id) {
+  if (confirm('Are you sure?')) {
+    await roleService.remove(id)
+    load()
+  }
+}
+
+onMounted(load)
+</script>

--- a/src/components/users/UserDetail.vue
+++ b/src/components/users/UserDetail.vue
@@ -1,0 +1,24 @@
+<template>
+  <div v-if="user">
+    <h1>User #{{ user.id }}</h1>
+    <ul class="list-group mb-3">
+      <li class="list-group-item">Username: {{ user.username }}</li>
+      <li class="list-group-item">Roles: {{ (user.roles || []).map(r => r.name).join(', ') }}</li>
+    </ul>
+    <router-link to="/users" class="btn btn-secondary">Back to list</router-link>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import userService from '@/services/userService'
+
+const route = useRoute()
+const user = ref(null)
+
+onMounted(async () => {
+  const { data } = await userService.get(route.params.id)
+  user.value = data
+})
+</script>

--- a/src/components/users/UserForm.vue
+++ b/src/components/users/UserForm.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <h1>{{ isEdit ? 'Edit' : 'Create' }} User</h1>
+    <form @submit.prevent="submit">
+      <div class="mb-3">
+        <label class="form-label">Username</label>
+        <input v-model="form.username" class="form-control" />
+      </div>
+      <div class="mb-3" v-if="!isEdit">
+        <label class="form-label">Password</label>
+        <input v-model="form.password" type="password" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Roles</label>
+        <select v-model="form.role_ids" multiple class="form-select">
+          <option v-for="r in roles" :key="r.id" :value="r.id">{{ r.name }}</option>
+        </select>
+      </div>
+      <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { reactive, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import userService from '@/services/userService'
+import roleService from '@/services/roleService'
+
+const router = useRouter()
+
+const props = defineProps({ isEdit: Boolean, id: Number })
+
+const roles = ref([])
+const form = reactive({
+  username: '',
+  password: '',
+  role_ids: []
+})
+
+onMounted(async () => {
+  const { data: roleData } = await roleService.getAll()
+  roles.value = roleData
+  if (props.isEdit) {
+    const { data } = await userService.get(props.id)
+    form.username = data.username
+    form.role_ids = (data.roles || []).map(r => r.id)
+  }
+})
+
+async function submit() {
+  if (props.isEdit) {
+    await userService.update(props.id, form)
+  } else {
+    await userService.create(form)
+  }
+  router.push('/users')
+}
+</script>

--- a/src/components/users/UsersList.vue
+++ b/src/components/users/UsersList.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <h1>Users</h1>
+    <router-link to="/users/create" class="btn btn-primary mb-3">Add New User</router-link>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>ID</th><th>Username</th><th>Roles</th><th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="u in users" :key="u.id">
+          <td>{{ u.id }}</td>
+          <td>{{ u.username }}</td>
+          <td>{{ (u.roles || []).map(r => r.name).join(', ') }}</td>
+          <td>
+            <router-link :to="`/users/${u.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
+            <router-link :to="`/users/${u.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
+            <button class="btn btn-sm btn-danger" @click.prevent="remove(u.id)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import userService from '@/services/userService'
+
+const users = ref([])
+
+async function load() {
+  const { data } = await userService.getAll()
+  users.value = data
+}
+
+async function remove(id) {
+  if (confirm('Are you sure?')) {
+    await userService.remove(id)
+    load()
+  }
+}
+
+onMounted(load)
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -21,6 +21,15 @@ import TicketDetail from '@/components/tickets/TicketDetail.vue'
 
 import ManualReviewsList from '@/components/manualReviews/ManualReviewsList.vue'
 import ManualReviewDetail from '@/components/manualReviews/ManualReviewDetail.vue'
+import UsersList from '@/components/users/UsersList.vue'
+import UserForm from '@/components/users/UserForm.vue'
+import UserDetail from '@/components/users/UserDetail.vue'
+import RolesList from '@/components/roles/RolesList.vue'
+import RoleForm from '@/components/roles/RoleForm.vue'
+import RoleDetail from '@/components/roles/RoleDetail.vue'
+import PermissionsList from '@/components/permissions/PermissionsList.vue'
+import PermissionForm from '@/components/permissions/PermissionForm.vue'
+import PermissionDetail from '@/components/permissions/PermissionDetail.vue'
 import Login from '@/components/Login.vue'
 import { useAuthStore } from '@/stores/auth'
 
@@ -53,6 +62,21 @@ const routes = [
 
   { path: '/manual-reviews', component: ManualReviewsList },
   { path: '/manual-reviews/:id', component: ManualReviewDetail, props: true },
+
+  { path: '/users', component: UsersList, meta: { requiresAdmin: true } },
+  { path: '/users/create', component: UserForm, props: { isEdit: false }, meta: { requiresAdmin: true } },
+  { path: '/users/:id/edit', component: UserForm, props: route => ({ isEdit: true, id: +route.params.id }), meta: { requiresAdmin: true } },
+  { path: '/users/:id', component: UserDetail, props: true, meta: { requiresAdmin: true } },
+
+  { path: '/roles', component: RolesList, meta: { requiresAdmin: true } },
+  { path: '/roles/create', component: RoleForm, props: { isEdit: false }, meta: { requiresAdmin: true } },
+  { path: '/roles/:id/edit', component: RoleForm, props: route => ({ isEdit: true, id: +route.params.id }), meta: { requiresAdmin: true } },
+  { path: '/roles/:id', component: RoleDetail, props: true, meta: { requiresAdmin: true } },
+
+  { path: '/permissions', component: PermissionsList, meta: { requiresAdmin: true } },
+  { path: '/permissions/create', component: PermissionForm, props: { isEdit: false }, meta: { requiresAdmin: true } },
+  { path: '/permissions/:id/edit', component: PermissionForm, props: route => ({ isEdit: true, id: +route.params.id }), meta: { requiresAdmin: true } },
+  { path: '/permissions/:id', component: PermissionDetail, props: true, meta: { requiresAdmin: true } },
 ]
 
 const router = createRouter({
@@ -67,6 +91,9 @@ router.beforeEach((to, from, next) => {
 
   if (authRequired && !auth.token) {
     return next('/login')
+  }
+  if (to.meta.requiresAdmin && !auth.roles.includes('admin')) {
+    return next('/')
   }
   next()
 })

--- a/src/services/permissionService.js
+++ b/src/services/permissionService.js
@@ -1,0 +1,9 @@
+import API from './api'
+
+export default {
+  getAll()            { return API.get('/permissions') },
+  get(id)             { return API.get(`/permissions/${id}`) },
+  create(payload)     { return API.post('/permissions', payload) },
+  update(id, payload) { return API.put(`/permissions/${id}`, payload) },
+  remove(id)          { return API.delete(`/permissions/${id}`) },
+}

--- a/src/services/roleService.js
+++ b/src/services/roleService.js
@@ -1,0 +1,9 @@
+import API from './api'
+
+export default {
+  getAll()            { return API.get('/roles') },
+  get(id)             { return API.get(`/roles/${id}`) },
+  create(payload)     { return API.post('/roles', payload) },
+  update(id, payload) { return API.put(`/roles/${id}`, payload) },
+  remove(id)          { return API.delete(`/roles/${id}`) },
+}

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,9 @@
+import API from './api'
+
+export default {
+  getAll()            { return API.get('/users') },
+  get(id)             { return API.get(`/users/${id}`) },
+  create(payload)     { return API.post('/users', payload) },
+  update(id, payload) { return API.put(`/users/${id}`, payload) },
+  remove(id)          { return API.delete(`/users/${id}`) },
+}

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -2,16 +2,32 @@ import { defineStore } from 'pinia'
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
-    token: localStorage.getItem('token') || ''
+    token: localStorage.getItem('token') || '',
+    roles: JSON.parse(localStorage.getItem('roles') || '[]'),
+    permissions: JSON.parse(localStorage.getItem('permissions') || '[]')
   }),
   actions: {
     setToken(token) {
       this.token = token
       localStorage.setItem('token', token)
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1]))
+        this.roles = payload.roles || []
+        this.permissions = payload.permissions || []
+        localStorage.setItem('roles', JSON.stringify(this.roles))
+        localStorage.setItem('permissions', JSON.stringify(this.permissions))
+      } catch (_) {
+        this.roles = []
+        this.permissions = []
+      }
     },
     clearToken() {
       this.token = ''
+      this.roles = []
+      this.permissions = []
       localStorage.removeItem('token')
+      localStorage.removeItem('roles')
+      localStorage.removeItem('permissions')
     }
   }
 })


### PR DESCRIPTION
## Summary
- allow decoding roles/permissions from JWT
- add service layers for users, roles, permissions
- create CRUD components for users/roles/permissions
- protect management routes with admin check and show nav links accordingly
- mention new screens in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684916c2bf28832686b0f7e061c430a4