### PR TITLE
Add statistics dashboard and sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@popperjs/core": "^2.11.8",
     "axios": "^1.9.0",
     "bootstrap": "^5.3.6",
+    "chart.js": "^4.4.9",
     "pinia": "^3.0.3",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,25 +1,29 @@
 <!-- App.vue -->
 <template>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-    <div class="container">
-      <router-link class="navbar-brand" to="/">Street</router-link>
-      <div class="navbar-nav">
-        <router-link class="nav-link" to="/cameras">Cameras</router-link>
-        <router-link class="nav-link" to="/locations">Locations</router-link>
-        <router-link class="nav-link" to="/zones">Zones</router-link>
-        <router-link class="nav-link" to="/poles">Poles</router-link>
-        <router-link class="nav-link" to="/tickets">Tickets</router-link>
-        <router-link class="nav-link" to="/manual-reviews">Manual Reviews</router-link>
-        <router-link v-if="auth.roles.includes('admin')" class="nav-link" to="/users">Users</router-link>
-        <router-link v-if="auth.roles.includes('admin')" class="nav-link" to="/roles">Roles</router-link>
-        <router-link v-if="auth.roles.includes('admin')" class="nav-link" to="/permissions">Permissions</router-link>
-        <router-link v-if="!auth.token" class="nav-link" to="/login">Login</router-link>
-        <a v-else class="nav-link" href="#" @click.prevent="logout">Logout</a>
+  <div class="d-flex">
+    <nav class="sidebar bg-primary text-light p-3">
+      <div class="text-center mb-4">
+        <img src="/vite.svg" alt="Logo" class="img-fluid mb-2" style="height: 40px;">
+        <router-link class="navbar-brand text-light" to="/statistics">Street</router-link>
       </div>
+      <ul class="nav flex-column">
+        <li class="nav-item"><router-link class="nav-link text-light" to="/statistics">Statistics</router-link></li>
+        <li class="nav-item"><router-link class="nav-link text-light" to="/cameras">Cameras</router-link></li>
+        <li class="nav-item"><router-link class="nav-link text-light" to="/locations">Locations</router-link></li>
+        <li class="nav-item"><router-link class="nav-link text-light" to="/zones">Zones</router-link></li>
+        <li class="nav-item"><router-link class="nav-link text-light" to="/poles">Poles</router-link></li>
+        <li class="nav-item"><router-link class="nav-link text-light" to="/tickets">Tickets</router-link></li>
+        <li class="nav-item"><router-link class="nav-link text-light" to="/manual-reviews">Manual Reviews</router-link></li>
+        <li class="nav-item" v-if="auth.roles.includes('admin')"><router-link class="nav-link text-light" to="/users">Users</router-link></li>
+        <li class="nav-item" v-if="auth.roles.includes('admin')"><router-link class="nav-link text-light" to="/roles">Roles</router-link></li>
+        <li class="nav-item" v-if="auth.roles.includes('admin')"><router-link class="nav-link text-light" to="/permissions">Permissions</router-link></li>
+        <li class="nav-item" v-if="!auth.token"><router-link class="nav-link text-light" to="/login">Login</router-link></li>
+        <li class="nav-item" v-else><a class="nav-link text-light" href="#" @click.prevent="logout">Logout</a></li>
+      </ul>
+    </nav>
+    <div class="flex-grow-1 p-3">
+      <router-view />
     </div>
-  </nav>
-  <div class="container">
-    <router-view />
   </div>
 </template>
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,5 +1,6 @@
 <template>
-  <div>
+  <div class="text-center">
+    <img src="/vite.svg" alt="Logo" class="mb-3" style="height: 64px;">
     <h1>Login</h1>
     <form @submit.prevent="submit">
       <div class="mb-3">

--- a/src/components/Statistics.vue
+++ b/src/components/Statistics.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <h1>Statistics</h1>
+    <div class="row">
+      <div class="col-md-6 mb-4">
+        <div class="chart-container">
+          <canvas id="barChart"></canvas>
+        </div>
+      </div>
+      <div class="col-md-6 mb-4">
+        <div class="chart-container">
+          <canvas id="pieChart"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue'
+import Chart from 'chart.js/auto'
+
+onMounted(() => {
+  const barCtx = document.getElementById('barChart')
+  new Chart(barCtx, {
+    type: 'bar',
+    data: {
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+      datasets: [{
+        label: 'Tickets',
+        data: [12, 19, 3, 5, 2],
+        backgroundColor: '#0d6efd'
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  })
+
+  const pieCtx = document.getElementById('pieChart')
+  new Chart(pieCtx, {
+    type: 'pie',
+    data: {
+      labels: ['Paid', 'Unpaid', 'Pending'],
+      datasets: [{
+        data: [50, 30, 20],
+        backgroundColor: ['#198754', '#dc3545', '#ffc107']
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  })
+})
+</script>
+
+<style scoped>
+.chart-container {
+  position: relative;
+  height: 300px;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,12 +30,14 @@ import RoleDetail from '@/components/roles/RoleDetail.vue'
 import PermissionsList from '@/components/permissions/PermissionsList.vue'
 import PermissionForm from '@/components/permissions/PermissionForm.vue'
 import PermissionDetail from '@/components/permissions/PermissionDetail.vue'
+import Statistics from '@/components/Statistics.vue'
 import Login from '@/components/Login.vue'
 import { useAuthStore } from '@/stores/auth'
 
 const routes = [
   { path: '/login', component: Login },
-  { path: '/', redirect: '/cameras' },
+  { path: '/', redirect: '/statistics' },
+  { path: '/statistics', component: Statistics },
   { path: '/cameras',          component: CamerasList },
   { path: '/cameras/create',   component: CameraForm,   props: { isEdit: false } },
   { path: '/cameras/:id/edit', component: CameraForm,   props: route => ({ isEdit: true, id: +route.params.id }) },

--- a/src/style.css
+++ b/src/style.css
@@ -8,3 +8,8 @@ body {
   background-color: #121212;
   color: #f8f9fa;
 }
+
+.sidebar {
+  width: 220px;
+  min-height: 100vh;
+}


### PR DESCRIPTION
## Summary
- add Chart.js dependency
- create `Statistics.vue` with demo bar and pie charts
- convert top navbar to sidebar layout with logo
- set login page and sidebar to show the logo
- use statistics page as default route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849457986308326bba181a5651ebf0d