### PR TITLE
Add second precision to camera clip inputs

### DIFF
--- a/src/components/cameras/CameraClip.vue
+++ b/src/components/cameras/CameraClip.vue
@@ -12,11 +12,11 @@
       </div>
       <div class="mb-3">
         <label class="form-label">Start</label>
-        <input type="datetime-local" v-model="start" class="form-control" />
+        <input type="datetime-local" step="1" v-model="start" class="form-control" />
       </div>
       <div class="mb-3">
         <label class="form-label">End</label>
-        <input type="datetime-local" v-model="end" class="form-control" />
+        <input type="datetime-local" step="1" v-model="end" class="form-control" />
       </div>
       <button type="submit" class="btn btn-primary">Get Clip</button>
     </form>


### PR DESCRIPTION
## Summary
- allow entering seconds when selecting start or end time for camera clips

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68497db1bca483268e5f8306983267f5