### PR TITLE
Add parking spot management

### DIFF
--- a/src/components/cameras/CamerasList.vue
+++ b/src/components/cameras/CamerasList.vue
@@ -18,6 +18,7 @@
           <td>{{ cam.vpn_ip || '–' }}</td>
           <td>
             <router-link :to="`/cameras/${cam.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
+            <router-link :to="`/cameras/${cam.id}/spots`" class="btn btn-sm btn-secondary me-1">Spots</router-link>
             <router-link :to="`/cameras/${cam.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
             <button class="btn btn-sm btn-danger" @click.prevent="deleteCamera(cam.id)">Delete</button>
           </td>

--- a/src/components/spots/AddSpotModal.vue
+++ b/src/components/spots/AddSpotModal.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="modal show d-block" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Add Spot</h5>
+          <button type="button" class="btn-close" @click="emit('close')"></button>
+        </div>
+        <div class="modal-body text-center">
+          <div v-if="!imageUrl">Loading frame...</div>
+          <div v-else style="position: relative; display: inline-block;" @click="recordPoint">
+            <img :src="imageUrl" ref="img" class="img-fluid" />
+            <svg
+              v-if="imgWidth && imgHeight"
+              :width="imgWidth"
+              :height="imgHeight"
+              class="position-absolute top-0 start-0"
+              style="pointer-events: none;"
+            >
+              <circle v-for="(p, i) in points" :key="i" :cx="p.x" :cy="p.y" r="4" fill="red" />
+              <polygon
+                v-if="points.length === 4"
+                :points="polygonPoints"
+                fill="rgba(255,0,0,0.3)"
+              />
+            </svg>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" @click="reset">Reset</button>
+          <button class="btn btn-primary" :disabled="points.length !== 4" @click="save">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, nextTick, computed } from 'vue'
+import cameraService from '@/services/cameraService'
+import spotService from '@/services/spotService'
+
+const props = defineProps({ cameraId: Number })
+const emit = defineEmits(['close', 'saved'])
+
+const imageUrl = ref('')
+const points = ref([])
+const img = ref(null)
+const imgWidth = ref(0)
+const imgHeight = ref(0)
+
+onMounted(async () => {
+  const { data } = await cameraService.getFrame(props.cameraId)
+  imageUrl.value = URL.createObjectURL(data)
+  await nextTick()
+  imgWidth.value = img.value.naturalWidth
+  imgHeight.value = img.value.naturalHeight
+})
+
+function recordPoint(e) {
+  if (points.value.length >= 4) return
+  const rect = img.value.getBoundingClientRect()
+  points.value.push({ x: e.clientX - rect.left, y: e.clientY - rect.top })
+}
+
+function reset() {
+  points.value = []
+}
+
+async function save() {
+  const xs = points.value.map(p => p.x)
+  const ys = points.value.map(p => p.y)
+  const payload = {
+    camera_id: props.cameraId,
+    bbox_x1: Math.min(...xs),
+    bbox_y1: Math.min(...ys),
+    bbox_x2: Math.max(...xs),
+    bbox_y2: Math.max(...ys),
+  }
+  await spotService.create(payload)
+  emit('saved')
+  emit('close')
+}
+
+const polygonPoints = computed(() => points.value.map(p => `${p.x},${p.y}`).join(' '))
+</script>

--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <h1>Camera {{ camId }} Spots</h1>
+    <button class="btn btn-primary mb-3" @click="showAdd = true">Add Spot</button>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>BBox</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="spot in spots" :key="spot.id">
+          <td>{{ spot.id }}</td>
+          <td>{{ spot.bbox_x1 }},{{ spot.bbox_y1 }},{{ spot.bbox_x2 }},{{ spot.bbox_y2 }}</td>
+          <td>
+            <button class="btn btn-sm btn-danger" @click.prevent="removeSpot(spot.id)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <router-link to="/cameras" class="btn btn-secondary mt-3">Back to Cameras</router-link>
+    <AddSpotModal v-if="showAdd" :camera-id="camId" @close="showAdd = false" @saved="load"/>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import spotService from '@/services/spotService'
+import AddSpotModal from './AddSpotModal.vue'
+
+const route = useRoute()
+const camId = +route.params.id
+
+const spots = ref([])
+const showAdd = ref(false)
+
+async function load() {
+  const { data } = await spotService.getForCamera(camId)
+  spots.value = data
+}
+
+async function removeSpot(id) {
+  if (confirm('Are you sure?')) {
+    await spotService.remove(id)
+    load()
+  }
+}
+
+onMounted(load)
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import CamerasList from '@/components/cameras/CamerasList.vue'
 import CameraForm   from '@/components/cameras/CameraForm.vue'
 import CameraDetail from '@/components/cameras/CameraDetail.vue'
 import CameraClip from '@/components/cameras/CameraClip.vue'
+import CameraSpots from '@/components/spots/CameraSpots.vue'
 
 import LocationsList from '@/components/locations/LocationsList.vue'
 import LocationForm   from '@/components/locations/LocationForm.vue'
@@ -43,6 +44,7 @@ const routes = [
   { path: '/cameras/create',   component: CameraForm,   props: { isEdit: false } },
   { path: '/cameras/:id/edit', component: CameraForm,   props: route => ({ isEdit: true, id: +route.params.id }) },
   { path: '/cameras/:id',      component: CameraDetail, props: true },
+  { path: '/cameras/:id/spots', component: CameraSpots },
   { path: '/camera-clip',      component: CameraClip },
   { path: '/locations',          component: LocationsList },
   { path: '/locations/create',   component: LocationForm, props: { isEdit: false } },

--- a/src/services/cameraService.js
+++ b/src/services/cameraService.js
@@ -12,4 +12,9 @@ export default {
       responseType: 'blob',
     })
   },
+  getFrame(camId) {
+    return API.get(`/cameras/${camId}/frame`, {
+      responseType: 'blob',
+    })
+  },
 }

--- a/src/services/spotService.js
+++ b/src/services/spotService.js
@@ -1,0 +1,8 @@
+import API from './api'
+
+export default {
+  getAll() { return API.get('/spots') },
+  getForCamera(camId) { return API.get(`/cameras/${camId}/spots`) },
+  create(payload) { return API.post('/spots', payload) },
+  remove(id) { return API.delete(`/spots/${id}`) },
+}


### PR DESCRIPTION
## Summary
- add spot management button on camera list
- list camera spots with add & delete features
- implement modal to select spot bounding box on a frame
- support camera frame retrieval and spot API service

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab46b71848326a3fc09e23a9d7951