### PR TITLE
Add spot number field and show in list

### DIFF
--- a/src/components/spots/AddSpotModal.vue
+++ b/src/components/spots/AddSpotModal.vue
@@ -25,10 +25,14 @@
               />
             </svg>
           </div>
+          <div class="mt-3 text-start">
+            <label class="form-label">Spot Number</label>
+            <input v-model.number="spotNumber" type="number" class="form-control" />
+          </div>
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" @click="reset">Reset</button>
-          <button class="btn btn-primary" :disabled="points.length !== 4" @click="save">Save</button>
+          <button class="btn btn-primary" :disabled="points.length !== 4 || !spotNumber" @click="save">Save</button>
         </div>
       </div>
     </div>
@@ -48,6 +52,7 @@ const points = ref([])
 const img = ref(null)
 const imgWidth = ref(0)
 const imgHeight = ref(0)
+const spotNumber = ref(null)
 
 onMounted(async () => {
   const { data } = await cameraService.getFrame(props.cameraId)
@@ -65,6 +70,7 @@ function recordPoint(e) {
 
 function reset() {
   points.value = []
+  spotNumber.value = null
 }
 
 async function save() {
@@ -72,6 +78,7 @@ async function save() {
   const ys = points.value.map(p => p.y)
   const payload = {
     camera_id: props.cameraId,
+    spot_number: spotNumber.value,
     bbox_x1: Math.min(...xs),
     bbox_y1: Math.min(...ys),
     bbox_x2: Math.max(...xs),

--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -6,6 +6,7 @@
       <thead>
         <tr>
           <th>ID</th>
+          <th>Number</th>
           <th>BBox</th>
           <th>Actions</th>
         </tr>
@@ -13,6 +14,7 @@
       <tbody>
         <tr v-for="spot in spots" :key="spot.id">
           <td>{{ spot.id }}</td>
+          <td>{{ spot.spot_number }}</td>
           <td>{{ spot.bbox_x1 }},{{ spot.bbox_y1 }},{{ spot.bbox_x2 }},{{ spot.bbox_y2 }}</td>
           <td>
             <button class="btn btn-sm btn-danger" @click.prevent="removeSpot(spot.id)">Delete</button>


### PR DESCRIPTION
## Summary
- allow specifying `spot_number` when adding a parking spot
- display the spot number in the spots table

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684abc3453088326a9cd60080b26a21a