### PR TITLE
Add spot number field and handle frame load errors

### DIFF
--- a/src/components/spots/AddSpotModal.vue
+++ b/src/components/spots/AddSpotModal.vue
@@ -7,8 +7,12 @@
           <button type="button" class="btn-close" @click="emit('close')"></button>
         </div>
         <div class="modal-body text-center">
-          <div v-if="!imageUrl">Loading frame...</div>
-          <div v-else style="position: relative; display: inline-block;" @click="recordPoint">
+          <div v-if="error" class="text-danger mb-2">
+            {{ error }}
+            <button class="btn btn-link" @click="loadFrame">Retry</button>
+          </div>
+          <div v-if="!imageUrl && !error">Loading frame...</div>
+          <div v-else-if="imageUrl" style="position: relative; display: inline-block;" @click="recordPoint">
             <img :src="imageUrl" ref="img" class="img-fluid" />
             <svg
               v-if="imgWidth && imgHeight"
@@ -25,10 +29,14 @@
               />
             </svg>
           </div>
+          <div class="mt-3 text-start">
+            <label class="form-label">Spot Number</label>
+            <input v-model.number="spotNumber" type="number" class="form-control" />
+          </div>
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" @click="reset">Reset</button>
-          <button class="btn btn-primary" :disabled="points.length !== 4" @click="save">Save</button>
+          <button class="btn btn-primary" :disabled="points.length !== 4 || !spotNumber || !!error" @click="save">Save</button>
         </div>
       </div>
     </div>
@@ -48,14 +56,24 @@ const points = ref([])
 const img = ref(null)
 const imgWidth = ref(0)
 const imgHeight = ref(0)
+const spotNumber = ref(null)
+const error = ref('')
 
-onMounted(async () => {
-  const { data } = await cameraService.getFrame(props.cameraId)
-  imageUrl.value = URL.createObjectURL(data)
-  await nextTick()
-  imgWidth.value = img.value.naturalWidth
-  imgHeight.value = img.value.naturalHeight
-})
+onMounted(loadFrame)
+
+async function loadFrame() {
+  try {
+    error.value = ''
+    const { data } = await cameraService.getFrame(props.cameraId)
+    imageUrl.value = URL.createObjectURL(data)
+    await nextTick()
+    imgWidth.value = img.value.naturalWidth
+    imgHeight.value = img.value.naturalHeight
+  } catch (err) {
+    console.error(err)
+    error.value = 'Failed to load frame.'
+  }
+}
 
 function recordPoint(e) {
   if (points.value.length >= 4) return
@@ -65,6 +83,7 @@ function recordPoint(e) {
 
 function reset() {
   points.value = []
+  spotNumber.value = null
 }
 
 async function save() {
@@ -72,6 +91,7 @@ async function save() {
   const ys = points.value.map(p => p.y)
   const payload = {
     camera_id: props.cameraId,
+    spot_number: spotNumber.value,
     bbox_x1: Math.min(...xs),
     bbox_y1: Math.min(...ys),
     bbox_x2: Math.max(...xs),

--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -6,6 +6,7 @@
       <thead>
         <tr>
           <th>ID</th>
+          <th>Number</th>
           <th>BBox</th>
           <th>Actions</th>
         </tr>
@@ -13,6 +14,7 @@
       <tbody>
         <tr v-for="spot in spots" :key="spot.id">
           <td>{{ spot.id }}</td>
+          <td>{{ spot.spot_number }}</td>
           <td>{{ spot.bbox_x1 }},{{ spot.bbox_y1 }},{{ spot.bbox_x2 }},{{ spot.bbox_y2 }}</td>
           <td>
             <button class="btn btn-sm btn-danger" @click.prevent="removeSpot(spot.id)">Delete</button>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -3,7 +3,7 @@ import { useAuthStore } from '@/stores/auth'
 
 const API = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 5000,
+  timeout: 10000,
 })
 
 API.interceptors.request.use(config => {


### PR DESCRIPTION
## Summary
- allow specifying `spot_number` when adding a parking spot
- display the spot number in the spots table
- improve add spot modal with retry on frame load failure
- increase API timeout to 10 seconds

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684abc3453088326a9cd60080b26a21a