### PR TITLE
Handle image load in AddSpotModal

### DIFF
--- a/src/components/spots/AddSpotModal.vue
+++ b/src/components/spots/AddSpotModal.vue
@@ -13,7 +13,7 @@
           </div>
           <div v-if="!imageUrl && !error">Loading frame...</div>
           <div v-else-if="imageUrl" style="position: relative; display: inline-block;" @click="recordPoint">
-            <img :src="imageUrl" ref="img" class="img-fluid" />
+            <img :src="imageUrl" ref="img" class="img-fluid" @load="onImgLoad" />
             <svg
               v-if="imgWidth && imgHeight"
               :width="imgWidth"
@@ -46,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, nextTick, computed } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import cameraService from '@/services/cameraService'
 import spotService from '@/services/spotService'
 
@@ -74,16 +74,18 @@ async function loadFrame() {
     error.value = ''
     const { data } = await cameraService.getFrame(props.cameraId)
     imageUrl.value = URL.createObjectURL(data)
-    await nextTick()
-    // store both natural and displayed dimensions
-    naturalWidth.value = img.value.naturalWidth
-    naturalHeight.value = img.value.naturalHeight
-    imgWidth.value = img.value.clientWidth
-    imgHeight.value = img.value.clientHeight
   } catch (err) {
     console.error(err)
     error.value = 'Failed to load frame.'
   }
+}
+
+function onImgLoad(e) {
+  const el = e.target
+  naturalWidth.value = el.naturalWidth
+  naturalHeight.value = el.naturalHeight
+  imgWidth.value = el.clientWidth
+  imgHeight.value = el.clientHeight
 }
 
 function recordPoint(e) {


### PR DESCRIPTION
## Summary
- set image dimensions when the element loads instead of inside `loadFrame`
- add an `onImgLoad` handler

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ac2229d8083269e9bf6d21b1f0922