### PR TITLE
Add spot detail viewer

### DIFF
--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -17,6 +17,7 @@
           <td>{{ spot.spot_number }}</td>
           <td>{{ spot.bbox_x1 }},{{ spot.bbox_y1 }},{{ spot.bbox_x2 }},{{ spot.bbox_y2 }}</td>
           <td>
+            <router-link :to="`/spots/${spot.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
             <button class="btn btn-sm btn-danger" @click.prevent="removeSpot(spot.id)">Delete</button>
           </td>
         </tr>

--- a/src/components/spots/SpotDetail.vue
+++ b/src/components/spots/SpotDetail.vue
@@ -1,0 +1,77 @@
+<template>
+  <div v-if="spot">
+    <h1>Spot #{{ spot.id }}</h1>
+    <ul class="list-group mb-3">
+      <li class="list-group-item">Spot Number: {{ spot.spot_number }}</li>
+      <li class="list-group-item">Camera ID: {{ spot.camera_id }}</li>
+    </ul>
+    <div v-if="imageUrl" style="position: relative; display: inline-block;">
+      <img :src="imageUrl" ref="img" class="img-fluid" @load="onImgLoad" />
+      <svg
+        v-if="imgWidth && imgHeight && box"
+        :width="imgWidth"
+        :height="imgHeight"
+        class="position-absolute top-0 start-0"
+        style="pointer-events: none;"
+      >
+        <rect
+          :x="box.x"
+          :y="box.y"
+          :width="box.width"
+          :height="box.height"
+          fill="rgba(255,0,0,0.3)"
+          stroke="red"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
+    <div class="mt-3">
+      <router-link :to="`/cameras/${spot.camera_id}/spots`" class="btn btn-secondary">Back to spots</router-link>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import spotService from '@/services/spotService'
+import cameraService from '@/services/cameraService'
+
+const route = useRoute()
+const spot = ref(null)
+const imageUrl = ref('')
+const img = ref(null)
+const imgWidth = ref(0)
+const imgHeight = ref(0)
+const naturalWidth = ref(0)
+const naturalHeight = ref(0)
+
+onMounted(async () => {
+  const { data } = await spotService.get(route.params.id)
+  spot.value = data
+  try {
+    const frameRes = await cameraService.getFrame(data.camera_id)
+    imageUrl.value = URL.createObjectURL(frameRes.data)
+  } catch (_) {}
+})
+
+function onImgLoad(e) {
+  const el = e.target
+  naturalWidth.value = el.naturalWidth
+  naturalHeight.value = el.naturalHeight
+  imgWidth.value = el.clientWidth
+  imgHeight.value = el.clientHeight
+}
+
+const box = computed(() => {
+  if (!spot.value || !imgWidth.value) return null
+  const ratioX = imgWidth.value / naturalWidth.value
+  const ratioY = imgHeight.value / naturalHeight.value
+  return {
+    x: spot.value.bbox_x1 * ratioX,
+    y: spot.value.bbox_y1 * ratioY,
+    width: (spot.value.bbox_x2 - spot.value.bbox_x1) * ratioX,
+    height: (spot.value.bbox_y2 - spot.value.bbox_y1) * ratioY,
+  }
+})
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import CameraForm   from '@/components/cameras/CameraForm.vue'
 import CameraDetail from '@/components/cameras/CameraDetail.vue'
 import CameraClip from '@/components/cameras/CameraClip.vue'
 import CameraSpots from '@/components/spots/CameraSpots.vue'
+import SpotDetail from '@/components/spots/SpotDetail.vue'
 
 import LocationsList from '@/components/locations/LocationsList.vue'
 import LocationForm   from '@/components/locations/LocationForm.vue'
@@ -45,6 +46,7 @@ const routes = [
   { path: '/cameras/:id/edit', component: CameraForm,   props: route => ({ isEdit: true, id: +route.params.id }) },
   { path: '/cameras/:id',      component: CameraDetail, props: true },
   { path: '/cameras/:id/spots', component: CameraSpots },
+  { path: '/spots/:id', component: SpotDetail, props: true },
   { path: '/camera-clip',      component: CameraClip },
   { path: '/locations',          component: LocationsList },
   { path: '/locations/create',   component: LocationForm, props: { isEdit: false } },

--- a/src/services/spotService.js
+++ b/src/services/spotService.js
@@ -2,6 +2,7 @@ import API from './api'
 
 export default {
   getAll() { return API.get('/spots') },
+  get(id) { return API.get(`/spots/${id}`) },
   getForCamera(camId) { return API.get(`/cameras/${camId}/spots`) },
   create(payload) { return API.post('/spots', payload) },
   remove(id) { return API.delete(`/spots/${id}`) },


### PR DESCRIPTION
## Summary
- show details for a single spot with bounding box overlay
- link each spot from the camera spots list
- expose `get()` in spot service
- register new `/spots/:id` route

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac423f52883268f5586f2691f2261