### PR TITLE
Add camera all spots overlay view

### DIFF
--- a/src/components/cameras/CamerasList.vue
+++ b/src/components/cameras/CamerasList.vue
@@ -19,6 +19,7 @@
           <td>
             <router-link :to="`/cameras/${cam.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
             <router-link :to="`/cameras/${cam.id}/spots`" class="btn btn-sm btn-secondary me-1">Spots</router-link>
+            <router-link :to="`/cameras/${cam.id}/all-spots`" class="btn btn-sm btn-secondary me-1">All Spots</router-link>
             <router-link :to="`/cameras/${cam.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
             <button class="btn btn-sm btn-danger" @click.prevent="deleteCamera(cam.id)">Delete</button>
           </td>

--- a/src/components/spots/CameraAllSpots.vue
+++ b/src/components/spots/CameraAllSpots.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <h1>Camera {{ camId }} All Spots</h1>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-if="imageUrl" style="position: relative; display: inline-block;">
+      <img :src="imageUrl" ref="img" class="img-fluid" @load="onImgLoad" />
+      <svg
+        v-if="imgWidth && imgHeight"
+        :width="imgWidth"
+        :height="imgHeight"
+        class="position-absolute top-0 start-0"
+        style="pointer-events: none;">
+        <rect
+          v-for="spot in spots"
+          :key="spot.id"
+          :x="boxFor(spot).x"
+          :y="boxFor(spot).y"
+          :width="boxFor(spot).width"
+          :height="boxFor(spot).height"
+          fill="rgba(255,0,0,0.3)"
+          stroke="red"
+          stroke-width="2" />
+      </svg>
+    </div>
+    <div class="mt-3">
+      <router-link :to="`/cameras/${camId}/spots`" class="btn btn-secondary">Back to Spots</router-link>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import cameraService from '@/services/cameraService'
+import spotService from '@/services/spotService'
+
+const route = useRoute()
+const camId = +route.params.id
+
+const imageUrl = ref('')
+const spots = ref([])
+const img = ref(null)
+const imgWidth = ref(0)
+const imgHeight = ref(0)
+const naturalWidth = ref(0)
+const naturalHeight = ref(0)
+const error = ref('')
+
+onMounted(async () => {
+  try {
+    const [frameRes, spotsRes] = await Promise.all([
+      cameraService.getFrame(camId).catch(() => null),
+      spotService.getForCamera(camId)
+    ])
+    if (frameRes) {
+      imageUrl.value = URL.createObjectURL(frameRes.data)
+    }
+    spots.value = spotsRes.data
+  } catch (_) {
+    error.value = 'Failed to load spots.'
+  }
+})
+
+function onImgLoad(e) {
+  const el = e.target
+  naturalWidth.value = el.naturalWidth
+  naturalHeight.value = el.naturalHeight
+  imgWidth.value = el.clientWidth
+  imgHeight.value = el.clientHeight
+}
+
+function boxFor(spot) {
+  if (!imgWidth.value) return { x:0, y:0, width:0, height:0 }
+  const ratioX = imgWidth.value / naturalWidth.value
+  const ratioY = imgHeight.value / naturalHeight.value
+  return {
+    x: spot.bbox_x1 * ratioX,
+    y: spot.bbox_y1 * ratioY,
+    width: (spot.bbox_x2 - spot.bbox_x1) * ratioX,
+    height: (spot.bbox_y2 - spot.bbox_y1) * ratioY
+  }
+}
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import CameraForm   from '@/components/cameras/CameraForm.vue'
 import CameraDetail from '@/components/cameras/CameraDetail.vue'
 import CameraClip from '@/components/cameras/CameraClip.vue'
 import CameraSpots from '@/components/spots/CameraSpots.vue'
+import CameraAllSpots from '@/components/spots/CameraAllSpots.vue'
 import SpotDetail from '@/components/spots/SpotDetail.vue'
 
 import LocationsList from '@/components/locations/LocationsList.vue'
@@ -46,6 +47,7 @@ const routes = [
   { path: '/cameras/:id/edit', component: CameraForm,   props: route => ({ isEdit: true, id: +route.params.id }) },
   { path: '/cameras/:id',      component: CameraDetail, props: true },
   { path: '/cameras/:id/spots', component: CameraSpots },
+  { path: '/cameras/:id/all-spots', component: CameraAllSpots },
   { path: '/spots/:id', component: SpotDetail, props: true },
   { path: '/camera-clip',      component: CameraClip },
   { path: '/locations',          component: LocationsList },


### PR DESCRIPTION
## Summary
- add `CameraAllSpots` component to display camera frame with all spots drawn
- add `All Spots` button in camera list
- register new route `/cameras/:id/all-spots`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ac8d7cb04832693b7aec802864f30