### PR TITLE
Switch spot geometry to polygons

### DIFF
--- a/src/components/spots/AddSpotModal.vue
+++ b/src/components/spots/AddSpotModal.vue
@@ -107,15 +107,22 @@ async function save() {
     x: p.x * ratioX,
     y: p.y * ratioY,
   }))
-  const xs = naturalPoints.map(p => p.x)
-  const ys = naturalPoints.map(p => p.y)
+  const rounded = naturalPoints.map(p => ({
+    x: Math.round(p.x),
+    y: Math.round(p.y)
+  }))
+  const [p1, p2, p3, p4] = rounded
   const payload = {
     camera_id: props.cameraId,
     spot_number: spotNumber.value,
-    bbox_x1: Math.round(Math.min(...xs)),
-    bbox_y1: Math.round(Math.min(...ys)),
-    bbox_x2: Math.round(Math.max(...xs)),
-    bbox_y2: Math.round(Math.max(...ys)),
+    p1_x: p1.x,
+    p1_y: p1.y,
+    p2_x: p2.x,
+    p2_y: p2.y,
+    p3_x: p3.x,
+    p3_y: p3.y,
+    p4_x: p4.x,
+    p4_y: p4.y,
   }
   await spotService.create(payload)
   emit('saved')

--- a/src/components/spots/CameraAllSpots.vue
+++ b/src/components/spots/CameraAllSpots.vue
@@ -10,13 +10,10 @@
         :height="imgHeight"
         class="position-absolute top-0 start-0"
         style="pointer-events: none;">
-        <rect
+        <polygon
           v-for="spot in spots"
           :key="spot.id"
-          :x="boxFor(spot).x"
-          :y="boxFor(spot).y"
-          :width="boxFor(spot).width"
-          :height="boxFor(spot).height"
+          :points="polygonFor(spot)"
           fill="rgba(255,0,0,0.3)"
           stroke="red"
           stroke-width="2" />
@@ -69,15 +66,16 @@ function onImgLoad(e) {
   imgHeight.value = el.clientHeight
 }
 
-function boxFor(spot) {
-  if (!imgWidth.value) return { x:0, y:0, width:0, height:0 }
+function polygonFor(spot) {
+  if (!imgWidth.value) return ''
   const ratioX = imgWidth.value / naturalWidth.value
   const ratioY = imgHeight.value / naturalHeight.value
-  return {
-    x: spot.bbox_x1 * ratioX,
-    y: spot.bbox_y1 * ratioY,
-    width: (spot.bbox_x2 - spot.bbox_x1) * ratioX,
-    height: (spot.bbox_y2 - spot.bbox_y1) * ratioY
-  }
+  const pts = [
+    { x: spot.p1_x, y: spot.p1_y },
+    { x: spot.p2_x, y: spot.p2_y },
+    { x: spot.p3_x, y: spot.p3_y },
+    { x: spot.p4_x, y: spot.p4_y }
+  ]
+  return pts.map(p => `${p.x * ratioX},${p.y * ratioY}`).join(' ')
 }
 </script>

--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -7,7 +7,7 @@
         <tr>
           <th>ID</th>
           <th>Number</th>
-          <th>BBox</th>
+          <th>Points</th>
           <th>Actions</th>
         </tr>
       </thead>
@@ -15,7 +15,7 @@
         <tr v-for="spot in spots" :key="spot.id">
           <td>{{ spot.id }}</td>
           <td>{{ spot.spot_number }}</td>
-          <td>{{ spot.bbox_x1 }},{{ spot.bbox_y1 }},{{ spot.bbox_x2 }},{{ spot.bbox_y2 }}</td>
+          <td>{{ formatPoints(spot) }}</td>
           <td>
             <router-link :to="`/spots/${spot.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
             <button class="btn btn-sm btn-danger" @click.prevent="removeSpot(spot.id)">Delete</button>
@@ -39,6 +39,10 @@ const camId = +route.params.id
 
 const spots = ref([])
 const showAdd = ref(false)
+
+function formatPoints(s) {
+  return `${s.p1_x},${s.p1_y} ${s.p2_x},${s.p2_y} ${s.p3_x},${s.p3_y} ${s.p4_x},${s.p4_y}`
+}
 
 async function load() {
   const { data } = await spotService.getForCamera(camId)

--- a/src/components/spots/SpotDetail.vue
+++ b/src/components/spots/SpotDetail.vue
@@ -8,17 +8,14 @@
     <div v-if="imageUrl" style="position: relative; display: inline-block;">
       <img :src="imageUrl" ref="img" class="img-fluid" @load="onImgLoad" />
       <svg
-        v-if="imgWidth && imgHeight && box"
+        v-if="imgWidth && imgHeight && polygon"
         :width="imgWidth"
         :height="imgHeight"
         class="position-absolute top-0 start-0"
         style="pointer-events: none;"
       >
-        <rect
-          :x="box.x"
-          :y="box.y"
-          :width="box.width"
-          :height="box.height"
+        <polygon
+          :points="polygon"
           fill="rgba(255,0,0,0.3)"
           stroke="red"
           stroke-width="2"
@@ -63,15 +60,16 @@ function onImgLoad(e) {
   imgHeight.value = el.clientHeight
 }
 
-const box = computed(() => {
-  if (!spot.value || !imgWidth.value) return null
+const polygon = computed(() => {
+  if (!spot.value || !imgWidth.value) return ''
   const ratioX = imgWidth.value / naturalWidth.value
   const ratioY = imgHeight.value / naturalHeight.value
-  return {
-    x: spot.value.bbox_x1 * ratioX,
-    y: spot.value.bbox_y1 * ratioY,
-    width: (spot.value.bbox_x2 - spot.value.bbox_x1) * ratioX,
-    height: (spot.value.bbox_y2 - spot.value.bbox_y1) * ratioY,
-  }
+  const pts = [
+    { x: spot.value.p1_x, y: spot.value.p1_y },
+    { x: spot.value.p2_x, y: spot.value.p2_y },
+    { x: spot.value.p3_x, y: spot.value.p3_y },
+    { x: spot.value.p4_x, y: spot.value.p4_y }
+  ]
+  return pts.map(p => `${p.x * ratioX},${p.y * ratioY}`).join(' ')
 })
 </script>


### PR DESCRIPTION
## Summary
- update AddSpotModal to send four corner points
- render polygons instead of bounding boxes
- display polygon coordinates in camera spot list

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a4d776d0c8326ba74cd3ff7715675