### PR TITLE
Add "All Spots" link in spots list

### DIFF
--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <h1>Camera {{ camId }} Spots</h1>
-    <button class="btn btn-primary mb-3" @click="showAdd = true">Add Spot</button>
+    <button class="btn btn-primary mb-3 me-2" @click="showAdd = true">Add Spot</button>
+    <router-link
+      :to="`/cameras/${camId}/all-spots`"
+      class="btn btn-secondary mb-3"
+    >All Spots</router-link>
     <table class="table table-striped">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- add link to view camera's "All Spots" overlay from the spots listing page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a568b8f5c8326a8069534e8886bce