### PR TITLE
Fix row color based on camera status

### DIFF
--- a/src/components/cameras/CamerasList.vue
+++ b/src/components/cameras/CamerasList.vue
@@ -53,8 +53,8 @@ async function deleteCamera(id) {
 
 function rowClass(cam) {
   const status = (cam.status || '').toString().toLowerCase()
-  if (status == 'ONLINE') return 'text-success'
-  if (status == 'OFFLINE') return 'text-success'
+  if (status === 'online') return 'table-success'
+  if (status === 'offline') return 'table-danger'
   return ''
 }
 


### PR DESCRIPTION
## Summary
- highlight camera table rows based on status: green for online and red for offline
- run `npm run build` to verify project builds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d3c8ec2c88326846f210ca9aa7bdd