### PR TITLE
Update sidebar color and hide on login

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <!-- App.vue -->
 <template>
   <div class="d-flex">
-    <nav class="sidebar bg-primary text-light p-3">
+    <nav v-if="showSidebar" class="sidebar text-light p-3">
       <div class="text-center mb-4">
         <img src="/vite.svg" alt="Logo" class="img-fluid mb-2" style="height: 40px;">
         <router-link class="navbar-brand text-light" to="/statistics">Street</router-link>
@@ -29,11 +29,15 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { useRouter } from 'vue-router'
 
 const auth = useAuthStore()
 const router = useRouter()
+const route = useRoute()
+
+const showSidebar = computed(() => route.path !== '/login')
 
 function logout() {
   auth.clearToken()

--- a/src/style.css
+++ b/src/style.css
@@ -16,7 +16,7 @@ body {
 .sidebar {
   width: 220px;
   min-height: 100vh;
-  background-color: var(--primary-color);
+  background-color: #022e48;
 }
 
 .sidebar .nav-link {


### PR DESCRIPTION
## Summary
- change sidebar background to `#022e48`
- hide sidebar on the login page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d41549b9c832698dbf6275b66e90f