### PR TITLE
Add sortable columns to all tables

### DIFF
--- a/src/components/locations/LocationsList.vue
+++ b/src/components/locations/LocationsList.vue
@@ -5,11 +5,14 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th><th>Name</th><th>Code</th><th>Actions</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('name')" style="cursor:pointer">Name <span v-if="sortKey === 'name'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('code')" style="cursor:pointer">Code <span v-if="sortKey === 'code'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="loc in locations" :key="loc.id">
+        <tr v-for="loc in sortedLocations" :key="loc.id">
           <td>{{ loc.id }}</td>
           <td>{{ loc.name }}</td>
           <td>{{ loc.code }}</td>
@@ -27,8 +30,10 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import locationService from '@/services/locationService'
+import useSortable from '@/composables/useSortable'
 
 const locations = ref([])
+const { sortKey, sortAsc, sortedItems: sortedLocations, sortBy } = useSortable(locations, 'id')
 
 async function load() {
   const { data } = await locationService.getAll()

--- a/src/components/manualReviews/ManualReviewsList.vue
+++ b/src/components/manualReviews/ManualReviewsList.vue
@@ -14,17 +14,17 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Camera ID</th>
-          <th>spot_number</th>
-          <th>event_time</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('camera_id')" style="cursor:pointer">Camera ID <span v-if="sortKey === 'camera_id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('spot_number')" style="cursor:pointer">spot_number <span v-if="sortKey === 'spot_number'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('event_time')" style="cursor:pointer">event_time <span v-if="sortKey === 'event_time'">{{ sortAsc ? '▲' : '▼' }}</span></th>
           <th>Plate</th>
-          <th>Status</th>
+          <th @click="sortBy('plate_status')" style="cursor:pointer">Status <span v-if="sortKey === 'plate_status'">{{ sortAsc ? '▲' : '▼' }}</span></th>
           <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="rev in reviews" :key="rev.id">
+        <tr v-for="rev in sortedReviews" :key="rev.id">
           <td>{{ rev.id }}</td>
           <td>{{ rev.camera_id }}</td>
           <td>{{ rev.spot_number }}</td>
@@ -71,8 +71,10 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue'
 import manualReviewService from '@/services/manualReviewService'
+import useSortable from '@/composables/useSortable'
 
 const reviews = ref([])
+const { sortKey, sortAsc, sortedItems: sortedReviews, sortBy } = useSortable(reviews, 'id')
 const page = ref(1)
 const pageSize = ref(50)
 const total = ref(0)

--- a/src/components/permissions/PermissionsList.vue
+++ b/src/components/permissions/PermissionsList.vue
@@ -5,11 +5,13 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th><th>Name</th><th>Actions</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('name')" style="cursor:pointer">Name <span v-if="sortKey === 'name'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="p in permissions" :key="p.id">
+        <tr v-for="p in sortedPermissions" :key="p.id">
           <td>{{ p.id }}</td>
           <td>{{ p.name }}</td>
           <td>
@@ -26,8 +28,10 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import permissionService from '@/services/permissionService'
+import useSortable from '@/composables/useSortable'
 
 const permissions = ref([])
+const { sortKey, sortAsc, sortedItems: sortedPermissions, sortBy } = useSortable(permissions, 'id')
 
 async function load() {
   const { data } = await permissionService.getAll()

--- a/src/components/poles/PolesList.vue
+++ b/src/components/poles/PolesList.vue
@@ -5,11 +5,16 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th><th>API Pole ID</th><th>Code</th><th>Zone</th><th>Location</th><th>Actions</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('api_pole_id')" style="cursor:pointer">API Pole ID <span v-if="sortKey === 'api_pole_id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('code')" style="cursor:pointer">Code <span v-if="sortKey === 'code'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('zone_id')" style="cursor:pointer">Zone <span v-if="sortKey === 'zone_id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('location_id')" style="cursor:pointer">Location <span v-if="sortKey === 'location_id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="pole in poles" :key="pole.id">
+        <tr v-for="pole in sortedPoles" :key="pole.id">
           <td>{{ pole.id }}</td>
           <td>{{ pole.api_pole_id }}</td>
           <td>{{ pole.code }}</td>
@@ -29,8 +34,10 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import poleService from '@/services/poleService'
+import useSortable from '@/composables/useSortable'
 
 const poles = ref([])
+const { sortKey, sortAsc, sortedItems: sortedPoles, sortBy } = useSortable(poles, 'id')
 
 async function load() {
   const { data } = await poleService.getAll()

--- a/src/components/roles/RolesList.vue
+++ b/src/components/roles/RolesList.vue
@@ -5,11 +5,13 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th><th>Name</th><th>Actions</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('name')" style="cursor:pointer">Name <span v-if="sortKey === 'name'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="r in roles" :key="r.id">
+        <tr v-for="r in sortedRoles" :key="r.id">
           <td>{{ r.id }}</td>
           <td>{{ r.name }}</td>
           <td>
@@ -26,8 +28,10 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import roleService from '@/services/roleService'
+import useSortable from '@/composables/useSortable'
 
 const roles = ref([])
+const { sortKey, sortAsc, sortedItems: sortedRoles, sortBy } = useSortable(roles, 'id')
 
 async function load() {
   const { data } = await roleService.getAll()

--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -27,14 +27,14 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Number</th>
-          <th>Points</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('spot_number')" style="cursor:pointer">Number <span v-if="sortKey === 'spot_number'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('p1_x')" style="cursor:pointer">Points <span v-if="sortKey === 'p1_x'">{{ sortAsc ? '▲' : '▼' }}</span></th>
           <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="spot in spots" :key="spot.id">
+        <tr v-for="spot in sortedSpots" :key="spot.id">
           <td>{{ spot.id }}</td>
           <td>{{ spot.spot_number }}</td>
           <td>{{ formatPoints(spot) }}</td>
@@ -52,6 +52,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import useSortable from '@/composables/useSortable'
 import { useRoute } from 'vue-router'
 import spotService from '@/services/spotService'
 import cameraService from '@/services/cameraService'
@@ -61,6 +62,7 @@ const route = useRoute()
 const camId = +route.params.id
 
 const spots = ref([])
+const { sortKey, sortAsc, sortedItems: sortedSpots, sortBy } = useSortable(spots, 'id')
 const showAdd = ref(false)
 const camera = ref(null)
 const imageUrl = ref('')

--- a/src/components/tickets/TicketsList.vue
+++ b/src/components/tickets/TicketsList.vue
@@ -70,19 +70,19 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Plate Number</th>
-          <th>Plate Code</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('plate_number')" style="cursor:pointer">Plate Number <span v-if="sortKey === 'plate_number'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('plate_code')" style="cursor:pointer">Plate Code <span v-if="sortKey === 'plate_code'">{{ sortAsc ? '▲' : '▼' }}</span></th>
           <th>Image</th>
-          <th>Camera ID</th>
-          <th>Spot Number</th>
-          <th>Entry Time</th>
-          <th>Exit Time</th>
+          <th @click="sortBy('camera_id')" style="cursor:pointer">Camera ID <span v-if="sortKey === 'camera_id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('spot_number')" style="cursor:pointer">Spot Number <span v-if="sortKey === 'spot_number'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('entry_time')" style="cursor:pointer">Entry Time <span v-if="sortKey === 'entry_time'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('exit_time')" style="cursor:pointer">Exit Time <span v-if="sortKey === 'exit_time'">{{ sortAsc ? '▲' : '▼' }}</span></th>
           <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="ticket in tickets" :key="ticket.id">
+        <tr v-for="ticket in sortedTickets" :key="ticket.id">
           <td>{{ ticket.id }}</td>
           <td>{{ ticket.plate_number }}</td>
           <td>{{ ticket.plate_code }}</td>
@@ -120,8 +120,10 @@
 <script setup>
 import { onMounted, ref, watch } from 'vue'
 import ticketService from '@/services/ticketService'
+import useSortable from '@/composables/useSortable'
 
 const tickets = ref([])
+const { sortKey, sortAsc, sortedItems: sortedTickets, sortBy } = useSortable(tickets, 'id')
 const page = ref(1)
 const pageSize = ref(50)
 const search = ref('')

--- a/src/components/users/UsersList.vue
+++ b/src/components/users/UsersList.vue
@@ -5,11 +5,14 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th><th>Username</th><th>Roles</th><th>Actions</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('username')" style="cursor:pointer">Username <span v-if="sortKey === 'username'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('roles')" style="cursor:pointer">Roles <span v-if="sortKey === 'roles'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="u in users" :key="u.id">
+        <tr v-for="u in sortedUsers" :key="u.id">
           <td>{{ u.id }}</td>
           <td>{{ u.username }}</td>
           <td>{{ (u.roles || []).map(r => r.name).join(', ') }}</td>
@@ -27,8 +30,10 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import userService from '@/services/userService'
+import useSortable from '@/composables/useSortable'
 
 const users = ref([])
+const { sortKey, sortAsc, sortedItems: sortedUsers, sortBy } = useSortable(users, 'id')
 
 async function load() {
   const { data } = await userService.getAll()

--- a/src/components/zones/ZonesList.vue
+++ b/src/components/zones/ZonesList.vue
@@ -5,11 +5,14 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th><th>Code</th><th>Location</th><th>Actions</th>
+          <th @click="sortBy('id')" style="cursor:pointer">ID <span v-if="sortKey === 'id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('code')" style="cursor:pointer">Code <span v-if="sortKey === 'code'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th @click="sortBy('location_id')" style="cursor:pointer">Location <span v-if="sortKey === 'location_id'">{{ sortAsc ? '▲' : '▼' }}</span></th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="zone in zones" :key="zone.id">
+        <tr v-for="zone in sortedZones" :key="zone.id">
           <td>{{ zone.id }}</td>
           <td>{{ zone.code }}</td>
           <td>{{ zone.location_id }}</td>
@@ -27,8 +30,10 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import zoneService from '@/services/zoneService'
+import useSortable from '@/composables/useSortable'
 
 const zones = ref([])
+const { sortKey, sortAsc, sortedItems: sortedZones, sortBy } = useSortable(zones, 'id')
 
 async function load() {
   const { data } = await zoneService.getAll()

--- a/src/composables/useSortable.js
+++ b/src/composables/useSortable.js
@@ -1,0 +1,33 @@
+import { ref, computed } from 'vue'
+
+export default function useSortable(items, defaultKey = 'id') {
+  const sortKey = ref(defaultKey)
+  const sortAsc = ref(true)
+
+  const sortedItems = computed(() => {
+    return [...items.value].sort((a, b) => {
+      const vA = a[sortKey.value]
+      const vB = b[sortKey.value]
+      if (vA == null) return 1
+      if (vB == null) return -1
+      if (typeof vA === 'number' && typeof vB === 'number')
+        return sortAsc.value ? vA - vB : vB - vA
+      const sA = vA.toString().toLowerCase()
+      const sB = vB.toString().toLowerCase()
+      if (sA < sB) return sortAsc.value ? -1 : 1
+      if (sA > sB) return sortAsc.value ? 1 : -1
+      return 0
+    })
+  })
+
+  function sortBy(key) {
+    if (sortKey.value === key) {
+      sortAsc.value = !sortAsc.value
+    } else {
+      sortKey.value = key
+      sortAsc.value = true
+    }
+  }
+
+  return { sortKey, sortAsc, sortedItems, sortBy }
+}


### PR DESCRIPTION
## Summary
- make a `useSortable` composable for sorting logic
- enable sorting on all list tables

## Testing
- `npm install`
- `npm run build` *(fails: Rollup failed to resolve import)*

------
https://chatgpt.com/codex/tasks/task_e_68621acd72b08326b13ad2c619a2a850