### PR TITLE
Restrict edit/delete UI to admins

### DIFF
--- a/src/components/cameras/CamerasList.vue
+++ b/src/components/cameras/CamerasList.vue
@@ -31,8 +31,16 @@
             <router-link :to="`/cameras/${cam.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
             <router-link :to="`/cameras/${cam.id}/spots`" class="btn btn-sm btn-secondary me-1">Spots</router-link>
             <router-link :to="`/cameras/${cam.id}/all-spots`" class="btn btn-sm btn-secondary me-1">All Spots</router-link>
-            <router-link :to="`/cameras/${cam.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
-            <button class="btn btn-sm btn-danger" @click.prevent="deleteCamera(cam.id)">Delete</button>
+            <router-link
+              v-if="auth.isAdmin"
+              :to="`/cameras/${cam.id}/edit`"
+              class="btn btn-sm btn-secondary me-1"
+            >Edit</router-link>
+            <button
+              v-if="auth.isAdmin"
+              class="btn btn-sm btn-danger"
+              @click.prevent="deleteCamera(cam.id)"
+            >Delete</button>
           </td>
         </tr>
       </tbody>
@@ -44,10 +52,12 @@
 import { onMounted, ref, computed } from 'vue'
 import cameraService from '@/services/cameraService'
 import * as XLSX from 'xlsx'
+import { useAuthStore } from '@/stores/auth'
 
 const cameras = ref([])
 const sortKey = ref('id')
 const sortAsc = ref(true)
+const auth = useAuthStore()
 
 const sortedCameras = computed(() => {
   return [...cameras.value].sort((a, b) => {

--- a/src/components/locations/LocationsList.vue
+++ b/src/components/locations/LocationsList.vue
@@ -18,8 +18,16 @@
           <td>{{ loc.code }}</td>
           <td>
             <router-link :to="`/locations/${loc.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
-            <router-link :to="`/locations/${loc.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
-            <button class="btn btn-sm btn-danger" @click.prevent="deleteLocation(loc.id)">Delete</button>
+            <router-link
+              v-if="auth.isAdmin"
+              :to="`/locations/${loc.id}/edit`"
+              class="btn btn-sm btn-secondary me-1"
+            >Edit</router-link>
+            <button
+              v-if="auth.isAdmin"
+              class="btn btn-sm btn-danger"
+              @click.prevent="deleteLocation(loc.id)"
+            >Delete</button>
           </td>
         </tr>
       </tbody>
@@ -31,9 +39,11 @@
 import { onMounted, ref } from 'vue'
 import locationService from '@/services/locationService'
 import useSortable from '@/composables/useSortable'
+import { useAuthStore } from '@/stores/auth'
 
 const locations = ref([])
 const { sortKey, sortAsc, sortedItems: sortedLocations, sortBy } = useSortable(locations, 'id')
+const auth = useAuthStore()
 
 async function load() {
   const { data } = await locationService.getAll()

--- a/src/components/poles/PolesList.vue
+++ b/src/components/poles/PolesList.vue
@@ -22,8 +22,16 @@
           <td>{{ pole.location_id }}</td>
           <td>
             <router-link :to="`/poles/${pole.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
-            <router-link :to="`/poles/${pole.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
-            <button class="btn btn-sm btn-danger" @click.prevent="deletePole(pole.id)">Delete</button>
+            <router-link
+              v-if="auth.isAdmin"
+              :to="`/poles/${pole.id}/edit`"
+              class="btn btn-sm btn-secondary me-1"
+            >Edit</router-link>
+            <button
+              v-if="auth.isAdmin"
+              class="btn btn-sm btn-danger"
+              @click.prevent="deletePole(pole.id)"
+            >Delete</button>
           </td>
         </tr>
       </tbody>
@@ -35,9 +43,11 @@
 import { onMounted, ref } from 'vue'
 import poleService from '@/services/poleService'
 import useSortable from '@/composables/useSortable'
+import { useAuthStore } from '@/stores/auth'
 
 const poles = ref([])
 const { sortKey, sortAsc, sortedItems: sortedPoles, sortBy } = useSortable(poles, 'id')
+const auth = useAuthStore()
 
 async function load() {
   const { data } = await poleService.getAll()

--- a/src/components/spots/CameraSpots.vue
+++ b/src/components/spots/CameraSpots.vue
@@ -40,7 +40,11 @@
           <td>{{ formatPoints(spot) }}</td>
           <td>
             <router-link :to="`/spots/${spot.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
-            <button class="btn btn-sm btn-danger" @click.prevent="removeSpot(spot.id)">Delete</button>
+            <button
+              v-if="auth.isAdmin"
+              class="btn btn-sm btn-danger"
+              @click.prevent="removeSpot(spot.id)"
+            >Delete</button>
           </td>
         </tr>
       </tbody>
@@ -56,6 +60,7 @@ import useSortable from '@/composables/useSortable'
 import { useRoute } from 'vue-router'
 import spotService from '@/services/spotService'
 import cameraService from '@/services/cameraService'
+import { useAuthStore } from '@/stores/auth'
 import AddSpotModal from './AddSpotModal.vue'
 
 const route = useRoute()
@@ -63,6 +68,7 @@ const camId = +route.params.id
 
 const spots = ref([])
 const { sortKey, sortAsc, sortedItems: sortedSpots, sortBy } = useSortable(spots, 'id')
+const auth = useAuthStore()
 const showAdd = ref(false)
 const camera = ref(null)
 const imageUrl = ref('')

--- a/src/components/tickets/TicketsList.vue
+++ b/src/components/tickets/TicketsList.vue
@@ -98,8 +98,16 @@
           <td>{{ ticket.exit_time }}</td>
           <td>
             <router-link :to="`/tickets/${ticket.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
-            <router-link :to="`/tickets/${ticket.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
-            <button class="btn btn-sm btn-danger" @click.prevent="deleteTicket(ticket.id)">Delete</button>
+            <router-link
+              v-if="auth.isAdmin"
+              :to="`/tickets/${ticket.id}/edit`"
+              class="btn btn-sm btn-secondary me-1"
+            >Edit</router-link>
+            <button
+              v-if="auth.isAdmin"
+              class="btn btn-sm btn-danger"
+              @click.prevent="deleteTicket(ticket.id)"
+            >Delete</button>
           </td>
         </tr>
       </tbody>
@@ -121,9 +129,11 @@
 import { onMounted, ref, watch } from 'vue'
 import ticketService from '@/services/ticketService'
 import useSortable from '@/composables/useSortable'
+import { useAuthStore } from '@/stores/auth'
 
 const tickets = ref([])
 const { sortKey, sortAsc, sortedItems: sortedTickets, sortBy } = useSortable(tickets, 'id')
+const auth = useAuthStore()
 const page = ref(1)
 const pageSize = ref(50)
 const search = ref('')

--- a/src/components/zones/ZonesList.vue
+++ b/src/components/zones/ZonesList.vue
@@ -18,8 +18,16 @@
           <td>{{ zone.location_id }}</td>
           <td>
             <router-link :to="`/zones/${zone.id}`" class="btn btn-sm btn-secondary me-1">View</router-link>
-            <router-link :to="`/zones/${zone.id}/edit`" class="btn btn-sm btn-secondary me-1">Edit</router-link>
-            <button class="btn btn-sm btn-danger" @click.prevent="deleteZone(zone.id)">Delete</button>
+            <router-link
+              v-if="auth.isAdmin"
+              :to="`/zones/${zone.id}/edit`"
+              class="btn btn-sm btn-secondary me-1"
+            >Edit</router-link>
+            <button
+              v-if="auth.isAdmin"
+              class="btn btn-sm btn-danger"
+              @click.prevent="deleteZone(zone.id)"
+            >Delete</button>
           </td>
         </tr>
       </tbody>
@@ -31,9 +39,11 @@
 import { onMounted, ref } from 'vue'
 import zoneService from '@/services/zoneService'
 import useSortable from '@/composables/useSortable'
+import { useAuthStore } from '@/stores/auth'
 
 const zones = ref([])
 const { sortKey, sortAsc, sortedItems: sortedZones, sortBy } = useSortable(zones, 'id')
+const auth = useAuthStore()
 
 async function load() {
   const { data } = await zoneService.getAll()

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -6,6 +6,9 @@ export const useAuthStore = defineStore('auth', {
     roles: JSON.parse(localStorage.getItem('roles') || '[]'),
     permissions: JSON.parse(localStorage.getItem('permissions') || '[]')
   }),
+  getters: {
+    isAdmin: state => state.roles.includes('admin')
+  },
   actions: {
     setToken(token) {
       this.token = token


### PR DESCRIPTION
## Summary
- expose `isAdmin` getter via auth store
- hide edit/delete buttons in list views unless user has admin role

## Testing
- `npm install`
- `npm run build` *(fails: Rollup failed to resolve import `/logo-1-dark.svg`)*

------
https://chatgpt.com/codex/tasks/task_e_686252386b188326b265cd4ca38e607c