### PR TITLE
Add location occupancy views

### DIFF
--- a/src/components/Statistics.vue
+++ b/src/components/Statistics.vue
@@ -13,12 +13,41 @@
         </div>
       </div>
     </div>
+    <h2 class="mt-4">Locations</h2>
+    <div class="row">
+      <div
+        v-for="loc in locations"
+        :key="loc.id"
+        class="col-md-3 mb-3"
+      >
+        <div
+          class="card h-100"
+          style="cursor:pointer"
+          @click="goToLocation(loc.id)"
+        >
+          <div class="card-body text-center">
+            <h5 class="card-title">{{ loc.name }}</h5>
+            <p class="card-text">{{ loc.code }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import locationService from '@/services/locationService'
 import Chart from 'chart.js/auto'
+
+const router = useRouter()
+const locations = ref([])
+
+async function loadLocations() {
+  const { data } = await locationService.getAll()
+  locations.value = data
+}
 
 onMounted(() => {
   const barCtx = document.getElementById('barChart')
@@ -50,10 +79,16 @@ onMounted(() => {
     },
     options: {
       responsive: true,
-      maintainAspectRatio: false
+    maintainAspectRatio: false
     }
   })
+
+  loadLocations()
 })
+
+function goToLocation(id) {
+  router.push(`/statistics/location/${id}`)
+}
 </script>
 
 <style scoped>

--- a/src/components/cropZones/CameraCropZones.vue
+++ b/src/components/cropZones/CameraCropZones.vue
@@ -41,7 +41,6 @@
         />
       </svg>
     </div>
-    </div>
     <div v-if="!imageUrl && !loading && !error">Loading frame...</div>
     <div class="mt-3">
       <button

--- a/src/components/statistics/CameraSpotsModal.vue
+++ b/src/components/statistics/CameraSpotsModal.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="modal show d-block" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Camera {{ camera.api_code || camera.id }} Spots</h5>
+          <button type="button" class="btn-close" @click="$emit('close')"></button>
+        </div>
+        <div class="modal-body">
+          <div class="row">
+            <div
+              v-for="spot in camera.spots"
+              :key="spot.id"
+              class="col-6 col-md-3 mb-2"
+            >
+              <div
+                class="card text-white text-center"
+                :class="spotOccupied(spot) ? 'bg-danger' : 'bg-success'"
+              >
+                <div class="card-body p-2">
+                  {{ spot.spot_number || spot.id }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({ camera: Object })
+
+function spotOccupied(spot) {
+  if ('occupied' in spot) return spot.occupied
+  if ('status' in spot) return spot.status === 'occupied'
+  if ('is_free' in spot) return !spot.is_free
+  return false
+}
+</script>

--- a/src/components/statistics/LocationOccupancy.vue
+++ b/src/components/statistics/LocationOccupancy.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <h1>Location {{ locationId }} Occupancy</h1>
+    <LoadingOverlay v-if="loading" />
+    <div class="row" v-if="!loading">
+      <div
+        v-for="cam in cameras"
+        :key="cam.id || cam.camera_id"
+        class="col-md-4 mb-3"
+      >
+        <div class="card h-100" style="cursor:pointer" @click="selectCamera(cam)">
+          <div class="card-body text-center">
+            <h5 class="card-title">{{ cam.api_code || cam.id || cam.camera_id }}</h5>
+            <p class="mb-1">Free: {{ cam.free }}</p>
+            <p class="mb-1">Occupied: {{ cam.occupied }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <CameraSpotsModal v-if="selected" :camera="selected" @close="selected=null" />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import occupancyService from '@/services/occupancyService'
+import LoadingOverlay from '../LoadingOverlay.vue'
+import CameraSpotsModal from './CameraSpotsModal.vue'
+
+const route = useRoute()
+const locationId = +route.params.id
+const cameras = ref([])
+const loading = ref(false)
+const selected = ref(null)
+
+async function load() {
+  loading.value = true
+  try {
+    const { data } = await occupancyService.getByLocation(locationId)
+    cameras.value = data.cameras || data
+  } finally {
+    loading.value = false
+  }
+}
+
+function selectCamera(cam) {
+  selected.value = cam
+}
+
+onMounted(load)
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -36,6 +36,7 @@ import PermissionsList from '@/components/permissions/PermissionsList.vue'
 import PermissionForm from '@/components/permissions/PermissionForm.vue'
 import PermissionDetail from '@/components/permissions/PermissionDetail.vue'
 import Statistics from '@/components/Statistics.vue'
+import LocationOccupancy from '@/components/statistics/LocationOccupancy.vue'
 import Login from '@/components/Login.vue'
 import { useAuthStore } from '@/stores/auth'
 
@@ -43,6 +44,7 @@ const routes = [
   { path: '/login', component: Login },
   { path: '/', redirect: '/statistics' },
   { path: '/statistics', component: Statistics },
+  { path: '/statistics/location/:id', component: LocationOccupancy, props: true },
   { path: '/cameras',          component: CamerasList },
   { path: '/cameras/create',   component: CameraForm,   props: { isEdit: false } },
   { path: '/cameras/:id/edit', component: CameraForm,   props: route => ({ isEdit: true, id: +route.params.id }) },

--- a/src/services/occupancyService.js
+++ b/src/services/occupancyService.js
@@ -1,0 +1,7 @@
+import API from './api'
+
+export default {
+  getByLocation(locationId) {
+    return API.get(`/camera-occupancy/${locationId}`)
+  }
+}


### PR DESCRIPTION
## Summary
- show locations on statistics page
- allow clicking a location to view camera occupancy
- view spot status for a camera in a modal
- add occupancyService helper
- fix stray closing tag in CameraCropZones.vue

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c5165b7c08326a5fa00213b895006