### PR TITLE
Add OCR image upload interface

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@
         <li class="nav-item"><router-link class="nav-link text-light" to="/statistics">Statistics</router-link></li>
         <li class="nav-item"><router-link class="nav-link text-light" to="/cameras">Cameras</router-link></li>
         <li class="nav-item"><router-link class="nav-link text-light" to="/camera-clip">Camera Clip</router-link></li>
+        <li class="nav-item"><router-link class="nav-link text-light" to="/img-ocr">Image OCR</router-link></li>
         <li class="nav-item"><router-link class="nav-link text-light" to="/locations">Locations</router-link></li>
         <li class="nav-item"><router-link class="nav-link text-light" to="/zones">Zones</router-link></li>
         <li class="nav-item"><router-link class="nav-link text-light" to="/poles">Poles</router-link></li>

--- a/src/components/OcrImage.vue
+++ b/src/components/OcrImage.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <h1>Image OCR</h1>
+    <form @submit.prevent="submit" class="mb-3">
+      <input type="file" @change="onFileChange" class="form-control mb-2" accept="image/*" />
+      <button class="btn btn-primary" :disabled="!file">Upload</button>
+    </form>
+    <div v-if="loading" class="position-relative" style="height: 80px;">
+      <LoadingOverlay />
+    </div>
+    <div v-if="error" class="alert alert-danger mt-2">{{ error }}</div>
+    <div v-if="result" class="mt-3">
+      <h5>Result</h5>
+      <pre>{{ result }}</pre>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import ocrService from '@/services/ocrService'
+import LoadingOverlay from './LoadingOverlay.vue'
+
+const file = ref(null)
+const result = ref(null)
+const error = ref('')
+const loading = ref(false)
+
+function onFileChange(e) {
+  file.value = e.target.files[0]
+}
+
+async function submit() {
+  if (!file.value) return
+  loading.value = true
+  error.value = ''
+  result.value = null
+  try {
+    const { data } = await ocrService.ocrImage(file.value)
+    result.value = JSON.stringify(data, null, 2)
+  } catch (_) {
+    error.value = 'Failed to perform OCR'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -36,6 +36,7 @@ import PermissionsList from '@/components/permissions/PermissionsList.vue'
 import PermissionForm from '@/components/permissions/PermissionForm.vue'
 import PermissionDetail from '@/components/permissions/PermissionDetail.vue'
 import Statistics from '@/components/Statistics.vue'
+import OcrImage from '@/components/OcrImage.vue'
 import LocationOccupancy from '@/components/statistics/LocationOccupancy.vue'
 import Login from '@/components/Login.vue'
 import { useAuthStore } from '@/stores/auth'
@@ -54,6 +55,7 @@ const routes = [
   { path: '/cameras/:id/crop-zones', component: CameraCropZones },
   { path: '/spots/:id', component: SpotDetail, props: true },
   { path: '/camera-clip',      component: CameraClip },
+  { path: '/img-ocr',      component: OcrImage },
   { path: '/locations',          component: LocationsList },
   { path: '/locations/create',   component: LocationForm, props: { isEdit: false } },
   { path: '/locations/:id/edit', component: LocationForm, props: route => ({ isEdit: true, id: +route.params.id }) },

--- a/src/services/ocrService.js
+++ b/src/services/ocrService.js
@@ -1,0 +1,11 @@
+import API from './api'
+
+export default {
+  ocrImage(file) {
+    const formData = new FormData()
+    formData.append('image', file)
+    return API.post('/ocr-image', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- add OCR service call for POST `/ocr-image`
- create `OcrImage.vue` for uploading an image and showing OCR result
- add OCR route and navigation link

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870982dd4ec8326a50acfa16731ddf5