### PR TITLE
Limit pagination to four pages ahead

### DIFF
--- a/src/components/manualReviews/ManualReviewsList.vue
+++ b/src/components/manualReviews/ManualReviewsList.vue
@@ -98,7 +98,11 @@ const images = ref({})
 const selectedImage = ref('')
 const loading = ref(false)
 const pageCount = computed(() => Math.ceil(total.value / pageSize.value))
-const pages = computed(() => Array.from({ length: pageCount.value }, (_, i) => i + 1))
+const pages = computed(() => {
+  const start = page.value
+  const end = Math.min(pageCount.value, start + 3)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
 
 async function fetchReviews() {
   loading.value = true

--- a/src/components/tickets/TicketsList.vue
+++ b/src/components/tickets/TicketsList.vue
@@ -174,7 +174,11 @@ const selectedImage = ref('')
 const images = ref({})
 const loading = ref(false)
 const pageCount = computed(() => Math.ceil(total.value / pageSize.value))
-const pages = computed(() => Array.from({ length: pageCount.value }, (_, i) => i + 1))
+const pages = computed(() => {
+  const start = page.value
+  const end = Math.min(pageCount.value, start + 3)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
 
 async function fetchTickets() {
   loading.value = true


### PR DESCRIPTION
## Summary
- limit displayed page numbers in ticket and manual review lists

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874b965f44c8326be36d3e9071a9143